### PR TITLE
Switch to Decoder-Only Transformers, Decouple Tokenization & Dynamic Device Assignment

### DIFF
--- a/trainite/config/base.py
+++ b/trainite/config/base.py
@@ -51,7 +51,7 @@ class ProjectConfig(BaseModel):
     trainer: TrainerConfig
     output: OutputConfig
     seed: int = 42
-    device: str = "cuda"
+    device: str = "auto"
 
 
 def load_yaml(path: str | Path) -> dict:

--- a/trainite/config/model.py
+++ b/trainite/config/model.py
@@ -7,7 +7,6 @@ class TransformerModelConfig(ComponentConfig):
     target: str = Field(
         default="trainite.models.transformer.build_transformer_model", alias="_target_"
     )
-    vocab_size: int = 32
     hidden_size: int = 64
     num_layers: int = 2
     num_heads: int = 2

--- a/trainite/datasets/string_reverse.py
+++ b/trainite/datasets/string_reverse.py
@@ -17,6 +17,7 @@ class CharTokenizer:
     ID 0 is reserved as the padding token.
     ID 1 is reserved as the BOS token.
     ID 2 is reserved as the EOS token.
+    ID 3 is reserved as the UNK token.
     """
 
     def __init__(self, alphabet: str = "abcdefghijklmnopqrstuvwxyz") -> None:
@@ -24,27 +25,56 @@ class CharTokenizer:
         self.pad_token_id = 0
         self.bos_token_id = 1
         self.eos_token_id = 2
+        self.unk_token_id = 3
+        
 
-        self.char_to_id = {c: i + 3 for i, c in enumerate(self.alphabet)}
-        self.id_to_char = {i + 3: c for i, c in enumerate(self.alphabet)}
+        self.char_to_id = {c: i + 4 for i, c in enumerate(self.alphabet)}
+        self.id_to_char = {i + 4: c for i, c in enumerate(self.alphabet)}
+
+        self.special_tokens = {
+            self.pad_token_id: "<pad>",
+            self.bos_token_id: "<bos>",
+            self.eos_token_id: "<eos>",
+            self.unk_token_id: "<unk>",
+        }
 
     @property
     def vocab_size(self) -> int:
         """Number of unique tokens in the vocabulary (includes special tokens)."""
-        return len(self.alphabet) + 3
+        return len(self.alphabet) + 4
 
     def encode(self, text: str) -> list[int]:
-        """Convert a string to a list of token IDs."""
-        return [self.char_to_id[c] for c in text]
+        """Convert a string to a list of token IDs, mapping unrecognized characters to UNK."""
+        return [self.char_to_id.get(c, self.unk_token_id) for c in text]
 
-    def decode(self, ids: list[int] | torch.Tensor) -> str:
-        """Convert a list of token IDs back to a string, skipping padding and special tokens."""
+    def decode(
+        self,
+        ids: list[int] | torch.Tensor,
+        skip_special_tokens: bool = True,
+        ignore_index: int = -100,
+    ) -> str:
+        """Convert a list of token IDs back to a string.
+
+        Args:
+            ids: List or tensor of token IDs to decode.
+            skip_special_tokens: If True, skips printing special tokens like <bos> and <eos>.
+            ignore_index: The token ID used for loss masking. These are silently ignored.
+        """
         if isinstance(ids, torch.Tensor):
             ids = ids.tolist()
-        special_token_ids = {self.pad_token_id, self.bos_token_id, self.eos_token_id}
-        return "".join(
-            self.id_to_char[i] for i in ids if i not in special_token_ids and i in self.id_to_char
-        )
+            
+        decoded_chars = []
+        for i in ids:
+            if i == ignore_index:
+                continue
+            if i in self.special_tokens:
+                if not skip_special_tokens or i == self.unk_token_id:
+                    decoded_chars.append(self.special_tokens[i])
+            elif i in self.id_to_char:
+                decoded_chars.append(self.id_to_char[i])
+            else:
+                decoded_chars.append(self.special_tokens[self.unk_token_id])
+        return "".join(decoded_chars)
 
 
 class StringReverseDataset(Dataset):
@@ -77,7 +107,7 @@ class StringReverseDataset(Dataset):
                 ).item()
 
             seq = torch.randint(
-                low=3,
+                low=4,
                 high=self.vocab_size,
                 size=(length,),
                 generator=generator,
@@ -108,8 +138,15 @@ class StringReverseDataset(Dataset):
             "labels": self.labels[index],
         }
 
-    def decode(self, ids: torch.Tensor) -> str:
-        return self.tokenizer.decode(ids)
+    def decode(
+        self,
+        ids: torch.Tensor,
+        skip_special_tokens: bool = True,
+        ignore_index: int = -100,
+    ) -> str:
+        return self.tokenizer.decode(
+            ids, skip_special_tokens=skip_special_tokens, ignore_index=ignore_index
+        )
 
 
 def collate_fn(batch: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:

--- a/trainite/datasets/string_reverse.py
+++ b/trainite/datasets/string_reverse.py
@@ -10,6 +10,37 @@ ALPHABET_PRESETS = {
 }
 
 
+class CharTokenizer:
+    """A simple character-level tokenizer.
+
+    Maps each character in the alphabet to a unique integer ID (1-indexed).
+    ID 0 is reserved as the padding token.
+    """
+
+    def __init__(self, alphabet: str = "abcdefghijklmnopqrstuvwxyz") -> None:
+        self.alphabet = ALPHABET_PRESETS.get(alphabet, alphabet)
+        self.pad_token_id = 0
+        self.char_to_id = {c: i + 1 for i, c in enumerate(self.alphabet)}
+        self.id_to_char = {i + 1: c for i, c in enumerate(self.alphabet)}
+
+    @property
+    def vocab_size(self) -> int:
+        """Number of unique tokens in the vocabulary (excludes padding token)."""
+        return len(self.alphabet)
+
+    def encode(self, text: str) -> list[int]:
+        """Convert a string to a list of token IDs."""
+        return [self.char_to_id[c] for c in text]
+
+    def decode(self, ids: list[int] | torch.Tensor) -> str:
+        """Convert a list of token IDs back to a string, skipping padding tokens."""
+        if isinstance(ids, torch.Tensor):
+            ids = ids.tolist()
+        return "".join(
+            self.id_to_char[i] for i in ids if i != self.pad_token_id
+        )
+
+
 class StringReverseDataset(Dataset):
     def __init__(
         self,
@@ -20,17 +51,15 @@ class StringReverseDataset(Dataset):
         fixed_length: bool = True,
         alphabet: str = "abcdefghijklmnopqrstuvwxyz",
     ) -> None:
-        self.alphabet = ALPHABET_PRESETS.get(alphabet, alphabet)
-        vocab_size = len(self.alphabet)
-        self.char_to_id = {c: i + 1 for i, c in enumerate(self.alphabet)}
-        self.id_to_char = {i + 1: c for i, c in enumerate(self.alphabet)}
+        self.tokenizer = CharTokenizer(alphabet)
+        self.vocab_size = self.tokenizer.vocab_size
 
         generator = torch.Generator().manual_seed(seed)
 
         if fixed_length:
             self.inputs = torch.randint(
                 low=1,
-                high=vocab_size + 1,
+                high=self.vocab_size + 1,
                 size=(size, max_seq_len),
                 generator=generator,
             )
@@ -47,7 +76,7 @@ class StringReverseDataset(Dataset):
 
                 seq = torch.randint(
                     low=1,
-                    high=vocab_size + 1,
+                    high=self.vocab_size + 1,
                     size=(length,),
                     generator=generator,
                 )
@@ -65,7 +94,7 @@ class StringReverseDataset(Dataset):
         }
 
     def decode(self, ids: torch.Tensor) -> str:
-        return "".join([self.id_to_char[idx.item()] for idx in ids if idx.item() != 0])
+        return self.tokenizer.decode(ids)
 
 
 def collate_fn(batch: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:

--- a/trainite/datasets/string_reverse.py
+++ b/trainite/datasets/string_reverse.py
@@ -13,31 +13,37 @@ ALPHABET_PRESETS = {
 class CharTokenizer:
     """A simple character-level tokenizer.
 
-    Maps each character in the alphabet to a unique integer ID (1-indexed).
+    Maps each character in the alphabet to a unique integer ID.
     ID 0 is reserved as the padding token.
+    ID 1 is reserved as the BOS token.
+    ID 2 is reserved as the EOS token.
     """
 
     def __init__(self, alphabet: str = "abcdefghijklmnopqrstuvwxyz") -> None:
         self.alphabet = ALPHABET_PRESETS.get(alphabet, alphabet)
         self.pad_token_id = 0
-        self.char_to_id = {c: i + 1 for i, c in enumerate(self.alphabet)}
-        self.id_to_char = {i + 1: c for i, c in enumerate(self.alphabet)}
+        self.bos_token_id = 1
+        self.eos_token_id = 2
+
+        self.char_to_id = {c: i + 3 for i, c in enumerate(self.alphabet)}
+        self.id_to_char = {i + 3: c for i, c in enumerate(self.alphabet)}
 
     @property
     def vocab_size(self) -> int:
-        """Number of unique tokens in the vocabulary (excludes padding token)."""
-        return len(self.alphabet)
+        """Number of unique tokens in the vocabulary (includes special tokens)."""
+        return len(self.alphabet) + 3
 
     def encode(self, text: str) -> list[int]:
         """Convert a string to a list of token IDs."""
         return [self.char_to_id[c] for c in text]
 
     def decode(self, ids: list[int] | torch.Tensor) -> str:
-        """Convert a list of token IDs back to a string, skipping padding tokens."""
+        """Convert a list of token IDs back to a string, skipping padding and special tokens."""
         if isinstance(ids, torch.Tensor):
             ids = ids.tolist()
+        special_token_ids = {self.pad_token_id, self.bos_token_id, self.eos_token_id}
         return "".join(
-            self.id_to_char[i] for i in ids if i != self.pad_token_id
+            self.id_to_char[i] for i in ids if i not in special_token_ids and i in self.id_to_char
         )
 
 
@@ -56,17 +62,13 @@ class StringReverseDataset(Dataset):
 
         generator = torch.Generator().manual_seed(seed)
 
-        if fixed_length:
-            self.inputs = torch.randint(
-                low=1,
-                high=self.vocab_size + 1,
-                size=(size, max_seq_len),
-                generator=generator,
-            )
-            self.labels = torch.flip(self.inputs, dims=[1])
-        else:
-            self.inputs = []
-            for _ in range(size):
+        self.inputs = []
+        self.labels = []
+
+        for _ in range(size):
+            if fixed_length:
+                length = max_seq_len
+            else:
                 length = torch.randint(
                     low=min_seq_len,
                     high=max_seq_len + 1,
@@ -74,15 +76,28 @@ class StringReverseDataset(Dataset):
                     generator=generator,
                 ).item()
 
-                seq = torch.randint(
-                    low=1,
-                    high=self.vocab_size + 1,
-                    size=(length,),
-                    generator=generator,
-                )
-                self.inputs.append(seq)
-
-            self.labels = [torch.flip(seq, dims=[0]) for seq in self.inputs]
+            seq = torch.randint(
+                low=3,
+                high=self.vocab_size,
+                size=(length,),
+                generator=generator,
+            )
+            
+            reversed_seq = torch.flip(seq, dims=[0])
+            
+            bos_t = torch.tensor([self.tokenizer.bos_token_id])
+            eos_t = torch.tensor([self.tokenizer.eos_token_id])
+            
+            full_seq = torch.cat([bos_t, seq, eos_t, reversed_seq, eos_t])
+            
+            input_ids = full_seq[:-1]
+            target_labels = full_seq[1:].clone()
+            
+            prompt_len = len(seq) + 2
+            target_labels[:prompt_len - 1] = -100
+            
+            self.inputs.append(input_ids)
+            self.labels.append(target_labels)
 
     def __len__(self) -> int:
         return len(self.inputs)

--- a/trainite/models/transformer.py
+++ b/trainite/models/transformer.py
@@ -48,7 +48,11 @@ class TransformerBlock(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         normed = self.norm1(x)
-        attn_output, _ = self.attention(normed, normed, normed)
+        sz = x.size(1)
+        mask = torch.nn.Transformer.generate_square_subsequent_mask(sz, device=x.device)
+        attn_output, _ = self.attention(
+            normed, normed, normed, attn_mask=mask, is_causal=True
+        )
         x = x + attn_output
 
         normed = self.norm2(x)

--- a/trainite/trainers/pretrainer.py
+++ b/trainite/trainers/pretrainer.py
@@ -38,15 +38,13 @@ class PreTrainer:
         torch.manual_seed(config.seed)
 
         self.config = config
-        self.device = device or config.device
+        resolved_device = config.device
+        if resolved_device == "auto":
+            resolved_device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = device or resolved_device
         self.epochs = epochs or config.trainer.epochs
         self.log_every_steps = log_every_steps or config.trainer.log_every_steps
         self.grad_clip_norm = grad_clip_norm or config.trainer.grad_clip_norm
-        self.model = model or instantiate(config.model)
-        self.model.to(self.device)
-        self.loss_fn = nn.CrossEntropyLoss()
-        self.optimizer = instantiate(config.optimizer, params=self.model.parameters())
-        self.lr = lr or config.optimizer.lr
 
         if train_loader is None:
             train_loader = self._build_dataloader(config.data.train)
@@ -63,6 +61,26 @@ class PreTrainer:
 
         self.train_loader = train_loader
         self.val_loader = val_loader
+
+        self.vocab_size = getattr(train_loader.dataset, "vocab_size", None)
+        model_params = config.model.model_dump(by_alias=True)
+        configured_vocab_size = model_params.get("vocab_size")
+
+        if configured_vocab_size is not None:
+            if self.vocab_size is not None and configured_vocab_size < self.vocab_size:
+                raise ValueError(
+                    f"Configured model vocab_size ({configured_vocab_size}) is smaller than "
+                    f"the dataset vocabulary size ({self.vocab_size}). "
+                    f"Please increase model vocab_size or remove it from config.yaml "
+                    f"to let it resolve automatically."
+                )
+            self.vocab_size = configured_vocab_size
+
+        self.model = model or instantiate(config.model, vocab_size=self.vocab_size)
+        self.model.to(self.device)
+        self.loss_fn = nn.CrossEntropyLoss()
+        self.optimizer = instantiate(config.optimizer, params=self.model.parameters())
+        self.lr = lr or config.optimizer.lr
         self.total_iters = len(self.train_loader) * self.epochs
         self.run_dir: Path | None = None
         self.handlers: dict = {}


### PR DESCRIPTION
# Description
This PR transitions the baseline transformer template to a **true Decoder-Only architecture** and automates runtime device, vocabulary-size, and sequence-level tokenization configurations.

### Key Enhancements

1. **Decoder-Only Causal Attention**
   * Modified `TransformerBlock` in `models/transformer.py` to dynamically generate and apply a square subsequent causal attention mask (`torch.nn.Transformer.generate_square_subsequent_mask`). This prevents the model from looking ahead during autoregressive training.

2. **Autoregressive Sequence Alignment & Masking**
   * Configured the `string-reverse` dataset to format training sequences as:
     `[BOS] + original_string + [EOS] + reversed_string + [EOS]`
   * Aligned inputs and targets by shifting `target_labels` by 1 (`full_seq[1:]`) relative to `input_ids` (`full_seq[:-1]`).
   * Applied standard prompt masking by setting loss targets for the prompt (`[BOS] + original_string + [EOS]`) to `-100`, forcing the model to only compute loss and learn on predicting the reversed string tokens.

3. **Modular Tokenizer Class**
   * Extracted a standalone `CharTokenizer` class inside `datasets/string_reverse.py` handling all token maps, special character allocations (`pad=0`, `bos=1`, `eos=2`), encoding, and decoding independently.

4. **Auto Device & Vocab-Size Detection**
   * Replaced the hardcoded `"cuda"` training device in `ProjectConfig` with `"auto"`, which dynamically resolves to GPU if available.
   * Completely removed the static `vocab_size` from `model.py` configuration. The model's vocabulary size is now dynamically extracted from the dataset at runtime, with Pydantic support to handle manual overrides when defined in `config.yaml`.
