### PR TITLE
Replace MultiheadAttention with custom Attention

### DIFF
--- a/trainite/datasets/string_reverse.py
+++ b/trainite/datasets/string_reverse.py
@@ -1,7 +1,6 @@
 import torch
-from torch.utils.data import Dataset
 from torch.nn.utils.rnn import pad_sequence
-
+from torch.utils.data import Dataset
 
 ALPHABET_PRESETS = {
     "@alpha": "abcdefghijklmnopqrstuvwxyz",
@@ -26,7 +25,6 @@ class CharTokenizer:
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.unk_token_id = 3
-        
 
         self.char_to_id = {c: i + 4 for i, c in enumerate(self.alphabet)}
         self.id_to_char = {i + 4: c for i, c in enumerate(self.alphabet)}
@@ -37,6 +35,9 @@ class CharTokenizer:
             self.eos_token_id: "<eos>",
             self.unk_token_id: "<unk>",
         }
+
+        for k, v in self.special_tokens.items():
+            self.id_to_char[k] = v
 
     @property
     def vocab_size(self) -> int:
@@ -62,7 +63,7 @@ class CharTokenizer:
         """
         if isinstance(ids, torch.Tensor):
             ids = ids.tolist()
-            
+
         decoded_chars = []
         for i in ids:
             if i == ignore_index:
@@ -112,20 +113,20 @@ class StringReverseDataset(Dataset):
                 size=(length,),
                 generator=generator,
             )
-            
+
             reversed_seq = torch.flip(seq, dims=[0])
-            
+
             bos_t = torch.tensor([self.tokenizer.bos_token_id])
             eos_t = torch.tensor([self.tokenizer.eos_token_id])
-            
+
             full_seq = torch.cat([bos_t, seq, eos_t, reversed_seq, eos_t])
-            
+
             input_ids = full_seq[:-1]
             target_labels = full_seq[1:].clone()
-            
+
             prompt_len = len(seq) + 2
-            target_labels[:prompt_len - 1] = -100
-            
+            target_labels[: prompt_len - 1] = -100
+
             self.inputs.append(input_ids)
             self.labels.append(target_labels)
 

--- a/trainite/models/transformer.py
+++ b/trainite/models/transformer.py
@@ -142,7 +142,10 @@ class TransformerModel(nn.Module):
         B, S = input_ids.shape
         x = self.embedding(input_ids) * math.sqrt(self.embedding.embedding_dim)
         x = self.pos_encoding(x)
-        padding_mask = (input_ids != self.embedding.padding_idx).reshape(B, 1, 1, S)
+        if (input_ids == self.embedding.padding_idx).any():
+            padding_mask = (input_ids != self.embedding.padding_idx).reshape(B, 1, 1, S)
+        else:
+            padding_mask = None
         for block in self.blocks:
             x = block(x, padding_mask=padding_mask)
         x = self.norm(x)

--- a/trainite/models/transformer.py
+++ b/trainite/models/transformer.py
@@ -24,6 +24,59 @@ class PositionalEncoding(nn.Module):
         return self.dropout(x)
 
 
+class Attention(nn.Module):
+    def __init__(self, embed_dim: int, num_heads: int, dropout: float = 0.1):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        assert self.num_heads * self.head_dim == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
+        self.qkv_projection = nn.Linear(embed_dim, embed_dim * 3, bias=False)
+        self.out = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.dropout = nn.Dropout(p=dropout)
+        self.dropout_p = dropout
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        padding_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        B, S, C = x.shape
+
+        qkv = self.qkv_projection(x)
+        q, k, v = qkv.chunk(3, dim=-1)
+
+        # Reshape for multi-head attention (B, S, num_heads, head_dim) and transpose to (B, num_heads, S, head_dim)
+        q = q.view(B, S, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(B, S, self.num_heads, self.head_dim).transpose(1, 2)
+        v = v.view(B, S, self.num_heads, self.head_dim).transpose(1, 2)
+        # padding mask shape should be (B,1,1,S) to broadcast correctly with attention scores of shape (B, num_heads, S, S)
+        if padding_mask is not None:
+            causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
+            mask = causal_mask & padding_mask
+            context = nn.functional.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                is_causal=False,
+                dropout_p=self.dropout_p if self.training else 0.0,
+            )
+        else:
+            context = nn.functional.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                is_causal=True,
+                dropout_p=self.dropout_p if self.training else 0.0,
+            )
+        context = context.transpose(1, 2).contiguous().view(B, S, C)
+        out = self.out(context)
+        return self.dropout(out), context
+
+
 class TransformerBlock(nn.Module):
     def __init__(
         self,
@@ -34,9 +87,7 @@ class TransformerBlock(nn.Module):
     ) -> None:
         super().__init__()
         self.norm1 = nn.LayerNorm(d_model)
-        self.attention = nn.MultiheadAttention(
-            d_model, num_heads, dropout=dropout, batch_first=True
-        )
+        self.attention = Attention(d_model, num_heads, dropout=dropout)
         self.norm2 = nn.LayerNorm(d_model)
         self.feedforward = nn.Sequential(
             nn.Linear(d_model, feedforward_dim),
@@ -46,13 +97,11 @@ class TransformerBlock(nn.Module):
             nn.Dropout(dropout),
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, padding_mask: torch.Tensor | None = None
+    ) -> torch.Tensor:
         normed = self.norm1(x)
-        sz = x.size(1)
-        mask = torch.nn.Transformer.generate_square_subsequent_mask(sz, device=x.device)
-        attn_output, _ = self.attention(
-            normed, normed, normed, attn_mask=mask, is_causal=True
-        )
+        attn_output, _ = self.attention(normed, padding_mask=padding_mask)
         x = x + attn_output
 
         normed = self.norm2(x)
@@ -90,10 +139,12 @@ class TransformerModel(nn.Module):
         self.norm = nn.LayerNorm(hidden_size)
 
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        B, S = input_ids.shape
         x = self.embedding(input_ids) * math.sqrt(self.embedding.embedding_dim)
         x = self.pos_encoding(x)
+        padding_mask = (input_ids != self.embedding.padding_idx).reshape(B, 1, 1, S)
         for block in self.blocks:
-            x = block(x)
+            x = block(x, padding_mask=padding_mask)
         x = self.norm(x)
         return self.proj(x)
 


### PR DESCRIPTION
This pull request introduces a custom multi-head attention implementation and updates the transformer model to use it, while also making some improvements to the string reverse dataset handling. The main changes are the addition of a new `Attention` class, replacing the previous use of PyTorch's built-in attention, and adjustments to how special tokens are handled in the dataset.

Transformer model improvements:

* Introduced a custom `Attention` class in `trainite/models/transformer.py` to replace the use of PyTorch's `nn.MultiheadAttention`, allowing more control over attention masking and dropout.
* Updated the `TransformerBlock` to use the new `Attention` class and refactored its forward method to support padding masks, improving flexibility for variable-length sequences. [[1]](diffhunk://#diff-23286b30be7f6477ea835453fdb3dcc78f5fe95323349abe4f0c6ebf17fe04e8L37-R90) [[2]](diffhunk://#diff-23286b30be7f6477ea835453fdb3dcc78f5fe95323349abe4f0c6ebf17fe04e8L49-R104)
* Modified the main transformer model to generate a padding mask based on input IDs and pass it through each block, ensuring proper masking during attention computation.

Dataset handling improvements:

* Updated the string reverse dataset to ensure special tokens are properly included in the `id_to_char` mapping, improving token decoding and consistency.
* Minor import cleanup and formatting changes in `trainite/datasets/string_reverse.py`. [[1]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L2-R3) [[2]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L30)Implement an Attention module using scaled_dot_product_attention with causal and padding-mask support, replace nn.MultiheadAttention in TransformerBlock, and propagate padding_mask from TransformerModel. Populate tokenizer.id_to_char with special tokens to support decoding.