### PR TITLE
Test script

### DIFF
--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -327,14 +327,6 @@ def init_project(args: argparse.Namespace) -> None:
                     collate_fn=collate_fn_config,
                 ),
             ),
-            val=SplitConfig(
-                dataset=val_dataset,
-                dataloader=DataLoaderConfig(
-                    batch_size=32,
-                    shuffle=False,
-                    collate_fn=collate_fn_config,
-                ),
-            ),
         ),
         trainer=trainer_component,
         output=output_config,

--- a/trainite/config/base.py
+++ b/trainite/config/base.py
@@ -42,6 +42,7 @@ class SplitConfig(BaseModel):
 class DataConfig(BaseModel):
     train: SplitConfig
     val: SplitConfig | None = None
+    test: SplitConfig | None = None
 
 
 class ProjectConfig(BaseModel):

--- a/trainite/config/trainer.py
+++ b/trainite/config/trainer.py
@@ -3,6 +3,5 @@ from trainite.config.base import TrainerConfig
 
 class PreTrainerConfig(TrainerConfig):
     epochs: int = 3
-    learning_rate: float = 1e-3
     log_every_steps: int = 10
     grad_clip_norm: float | None = None

--- a/trainite/templates/project/README.md
+++ b/trainite/templates/project/README.md
@@ -39,11 +39,13 @@ Trainite is a toolbox for training language models with PyTorch-Ignite. This pro
 Edit the files in `models/`. You can change the architecture, add new layers, or change how the loss is calculated if it's part of the model.
 
 ### Using Your Own Data
-Update the dataset factory and `Dataset` class in `dataset/`. In `config.yaml`, the `data` section allows you to configure `train` and `val` splits separately. Each split contains:
+Update the dataset factory and `Dataset` class in `dataset/`. In `config.yaml`, the `data` section allows you to configure `train`, `val` and `test` splits separately. Each split contains:
 - `dataset`: Configuration for the dataset builder.
 - `dataloader`: Parameters for the PyTorch DataLoader (batch size, shuffle, num_workers, etc.).
 
 If you omit the `val` section, the trainer will fall back to using the `train` configuration for validation (with a warning).
+
+If you omit the `test` section, the trainer will skip the testing phase after training (with a warning).
 
 ### Custom Training Logic
 If you need to change the training loop (e.g., add gradient clipping, custom logging, or a different optimization step), edit `trainer.py`. You can override methods of the `PreTrainer` (or `RLTrainer`) class.

--- a/trainite/trainers/pretrainer.py
+++ b/trainite/trainers/pretrainer.py
@@ -9,9 +9,9 @@ from ignite.handlers import (
     ModelCheckpoint,
     create_lr_scheduler_with_warmup,
 )
+from ignite.handlers.fbresearch_logger import FBResearchLogger
 from ignite.handlers.tensorboard_logger import OptimizerParamsHandler, TensorboardLogger
 from ignite.metrics import Accuracy, Loss, RunningAverage
-from ignite.handlers.fbresearch_logger import FBResearchLogger
 from ignite.utils import setup_logger
 from torch import nn
 from torch.optim.lr_scheduler import LinearLR
@@ -105,7 +105,6 @@ class PreTrainer:
             collate_fn = get_target(split_config.dataloader.collate_fn.target)
 
         return DataLoader(dataset, collate_fn=collate_fn, **dl_kwargs)
-
 
     def _make_run_dir(self) -> Path:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -338,7 +337,7 @@ class PreTrainer:
     def test(self, test_loader: DataLoader | None = None) -> None:
         loader = test_loader or self.test_loader
         if loader is None:
-            logger.warning("No test loader provided. Skipping testing.")
+            self.logger.warning("No test loader provided. Skipping testing.")
             return
 
         # Load best model if available
@@ -346,16 +345,16 @@ class PreTrainer:
         if checkpoint_handler and checkpoint_handler.last_checkpoint:
             checkpoint_path = checkpoint_handler.last_checkpoint
 
-            logger.info("Loading best model for testing from %s", checkpoint_path)
+            self.logger.info("Loading best model for testing from %s", checkpoint_path)
             checkpoint = torch.load(
                 checkpoint_path, map_location=self.device, weights_only=True
             )
             self.model.load_state_dict(checkpoint["model"])
 
-        logger.info("Running testing...")
+        self.logger.info("Running testing...")
         self.test_evaluator.run(loader)
         metrics = self.test_evaluator.state.metrics
-        logger.info(
+        self.logger.info(
             "Test results: loss=%.4f acc=%.4f",
             metrics["loss"],
             metrics["token_accuracy"],

--- a/trainite/trainers/pretrainer.py
+++ b/trainite/trainers/pretrainer.py
@@ -33,6 +33,7 @@ class PreTrainer:
         model: nn.Module | None = None,
         train_loader=None,
         val_loader=None,
+        test_loader=None,
         **kwargs,
     ) -> None:
         self.logger = setup_logger("trainer", level=logging.INFO)
@@ -60,8 +61,12 @@ class PreTrainer:
                 )
                 val_loader = self._build_dataloader(config.data.train)
 
+        if test_loader is None and config.data.test:
+            test_loader = self._build_dataloader(config.data.test)
+
         self.train_loader = train_loader
         self.val_loader = val_loader
+        self.test_loader = test_loader
 
         self.vocab_size = getattr(train_loader.dataset, "vocab_size", None)
         model_params = config.model.model_dump(by_alias=True)
@@ -88,6 +93,7 @@ class PreTrainer:
         self.engine = Engine(self._train_step)
         self.train_evaluator = Engine(self._eval_step)
         self.val_evaluator = Engine(self._eval_step)
+        self.test_evaluator = Engine(self._eval_step)
         self.metrics = {}
         self._attach_metrics()
 
@@ -174,17 +180,23 @@ class PreTrainer:
         train_accuracy = Accuracy(output_transform=self._exact_accuracy_transform)
         val_loss = Loss(self.loss_fn, output_transform=self._flatten_loss)
         val_accuracy = Accuracy(output_transform=self._exact_accuracy_transform)
+        test_loss = Loss(self.loss_fn, output_transform=self._flatten_loss)
+        test_accuracy = Accuracy(output_transform=self._exact_accuracy_transform)
 
         train_loss.attach(self.train_evaluator, "loss")
         train_accuracy.attach(self.train_evaluator, "exact_accuracy")
         val_loss.attach(self.val_evaluator, "loss")
         val_accuracy.attach(self.val_evaluator, "exact_accuracy")
+        test_loss.attach(self.test_evaluator, "loss")
+        test_accuracy.attach(self.test_evaluator, "exact_accuracy")
 
         self.metrics = {
             "train_loss": train_loss,
             "train_accuracy": train_accuracy,
             "val_loss": val_loss,
             "val_accuracy": val_accuracy,
+            "test_loss": test_loss,
+            "test_accuracy": test_accuracy,
         }
 
     def _attach_handlers(self) -> None:
@@ -288,6 +300,13 @@ class PreTrainer:
             metric_names=metric_names,
             global_step_transform=lambda *_: self.engine.state.epoch,
         )
+        tb_logger.attach_output_handler(
+            self.test_evaluator,
+            event_name=Events.COMPLETED,
+            tag="testing",
+            metric_names=metric_names,
+            global_step_transform=lambda *_: self.engine.state.epoch,
+        )
 
         tb_logger.attach(
             self.engine,
@@ -299,7 +318,7 @@ class PreTrainer:
     def _run_evaluations(self, engine: Engine) -> None:
         self.logger.info("Evaluating on training set...")
         self.train_evaluator.run(self.train_loader)
-        
+
         self.logger.info("Evaluating on validation set...")
         self.val_evaluator.run(self.val_loader)
 
@@ -314,6 +333,32 @@ class PreTrainer:
             train_metrics["exact_accuracy"],
             val_metrics["loss"],
             val_metrics["exact_accuracy"],
+        )
+
+    def test(self, test_loader: DataLoader | None = None) -> None:
+        loader = test_loader or self.test_loader
+        if loader is None:
+            logger.warning("No test loader provided. Skipping testing.")
+            return
+
+        # Load best model if available
+        checkpoint_handler = self.handlers.get("checkpoint_best")
+        if checkpoint_handler and checkpoint_handler.last_checkpoint:
+            checkpoint_path = checkpoint_handler.last_checkpoint
+
+            logger.info("Loading best model for testing from %s", checkpoint_path)
+            checkpoint = torch.load(
+                checkpoint_path, map_location=self.device, weights_only=True
+            )
+            self.model.load_state_dict(checkpoint["model"])
+
+        logger.info("Running testing...")
+        self.test_evaluator.run(loader)
+        metrics = self.test_evaluator.state.metrics
+        logger.info(
+            "Test results: loss=%.4f acc=%.4f",
+            metrics["loss"],
+            metrics["token_accuracy"],
         )
 
     def run(self) -> None:
@@ -331,6 +376,9 @@ class PreTrainer:
             self.handlers["tensorboard"].writer.add_text("config", str(config_data))
 
         self.engine.run(self.train_loader, max_epochs=self.epochs)
+
+        if self.test_loader:
+            self.test()
 
         if "tensorboard" in self.handlers:
             self.handlers["tensorboard"].close()

--- a/trainite/trainers/pretrainer.py
+++ b/trainite/trainers/pretrainer.py
@@ -357,7 +357,7 @@ class PreTrainer:
         self.logger.info(
             "Test results: loss=%.4f acc=%.4f",
             metrics["loss"],
-            metrics["token_accuracy"],
+            metrics["exact_accuracy"],
         )
 
     def run(self) -> None:

--- a/trainite/trainers/pretrainer.py
+++ b/trainite/trainers/pretrainer.py
@@ -56,10 +56,9 @@ class PreTrainer:
                 val_loader = self._build_dataloader(config.data.val)
             else:
                 self.logger.warning(
-                    "Validation config not provided. Falling back to training config for validation. "
-                    "This is not recommended for actual training as it may lead to overfitting."
+                    "Validation config not provided. Early stopping and best model checkpointing will be disabled. "
+                    "Only the last model will be saved."
                 )
-                val_loader = self._build_dataloader(config.data.train)
 
         if test_loader is None and config.data.test:
             test_loader = self._build_dataloader(config.data.test)
@@ -237,20 +236,23 @@ class PreTrainer:
         # 3. ModelCheckpoint
         to_save = {"model": self.model, "optimizer": self.optimizer}
 
-        def score_function(engine):
-            val_acc = engine.state.metrics["exact_accuracy"]
-            return val_acc
+        if self.val_loader:
 
-        checkpoint = ModelCheckpoint(
-            dirname=str(self.run_dir),
-            n_saved=1,
-            filename_prefix="best",
-            score_function=score_function,
-            score_name="val_acc",
-            require_empty=False,
-            global_step_transform=lambda *_: self.engine.state.epoch,
-        )
-        self.val_evaluator.add_event_handler(Events.COMPLETED, checkpoint, to_save)
+            def score_function(engine):
+                val_acc = engine.state.metrics["exact_accuracy"]
+                return val_acc
+
+            checkpoint = ModelCheckpoint(
+                dirname=str(self.run_dir),
+                n_saved=1,
+                filename_prefix="best",
+                score_function=score_function,
+                score_name="val_acc",
+                require_empty=False,
+                global_step_transform=lambda *_: self.engine.state.epoch,
+            )
+            self.val_evaluator.add_event_handler(Events.COMPLETED, checkpoint, to_save)
+            self.handlers["checkpoint_best"] = checkpoint
 
         last_checkpoint = ModelCheckpoint(
             dirname=str(self.run_dir),
@@ -261,18 +263,18 @@ class PreTrainer:
         )
         self.engine.add_event_handler(Events.EPOCH_COMPLETED, last_checkpoint, to_save)
 
-        self.handlers["checkpoint_best"] = checkpoint
         self.handlers["checkpoint_last"] = last_checkpoint
 
         # 4. EarlyStopping
-        early_stopping = EarlyStopping(
-            patience=3,
-            score_function=lambda engine: -engine.state.metrics["loss"],
-            trainer=self.engine,
-            min_delta=0.0,
-        )
-        self.val_evaluator.add_event_handler(Events.COMPLETED, early_stopping)
-        self.handlers["early_stopping"] = early_stopping
+        if self.val_loader:
+            early_stopping = EarlyStopping(
+                patience=3,
+                score_function=lambda engine: -engine.state.metrics["loss"],
+                trainer=self.engine,
+                min_delta=0.0,
+            )
+            self.val_evaluator.add_event_handler(Events.COMPLETED, early_stopping)
+            self.handlers["early_stopping"] = early_stopping
 
         # 5. TensorboardLogger
         log_dir = self.run_dir / "tensorboard" if self.run_dir else None
@@ -292,20 +294,22 @@ class PreTrainer:
             metric_names=metric_names,
             global_step_transform=lambda *_: self.engine.state.epoch,
         )
-        tb_logger.attach_output_handler(
-            self.val_evaluator,
-            event_name=Events.EPOCH_COMPLETED,
-            tag="validation",
-            metric_names=metric_names,
-            global_step_transform=lambda *_: self.engine.state.epoch,
-        )
-        tb_logger.attach_output_handler(
-            self.test_evaluator,
-            event_name=Events.COMPLETED,
-            tag="testing",
-            metric_names=metric_names,
-            global_step_transform=lambda *_: self.engine.state.epoch,
-        )
+        if self.val_loader:
+            tb_logger.attach_output_handler(
+                self.val_evaluator,
+                event_name=Events.EPOCH_COMPLETED,
+                tag="validation",
+                metric_names=metric_names,
+                global_step_transform=lambda *_: self.engine.state.epoch,
+            )
+        if self.test_loader:
+            tb_logger.attach_output_handler(
+                self.test_evaluator,
+                event_name=Events.COMPLETED,
+                tag="testing",
+                metric_names=metric_names,
+                global_step_transform=lambda *_: self.engine.state.epoch,
+            )
 
         tb_logger.attach(
             self.engine,
@@ -317,22 +321,28 @@ class PreTrainer:
     def _run_evaluations(self, engine: Engine) -> None:
         self.logger.info("Evaluating on training set...")
         self.train_evaluator.run(self.train_loader)
-
-        self.logger.info("Evaluating on validation set...")
-        self.val_evaluator.run(self.val_loader)
-
         train_metrics = self.train_evaluator.state.metrics
-        val_metrics = self.val_evaluator.state.metrics
         epoch = engine.state.epoch
 
-        self.logger.info(
-            "epoch=%s train_loss=%.4f train_acc=%.4f val_loss=%.4f val_acc=%.4f",
-            epoch,
-            train_metrics["loss"],
-            train_metrics["exact_accuracy"],
-            val_metrics["loss"],
-            val_metrics["exact_accuracy"],
-        )
+        if self.val_loader:
+            self.logger.info("Evaluating on validation set...")
+            self.val_evaluator.run(self.val_loader)
+            val_metrics = self.val_evaluator.state.metrics
+            self.logger.info(
+                "epoch=%s train_loss=%.4f train_acc=%.4f val_loss=%.4f val_acc=%.4f",
+                epoch,
+                train_metrics["loss"],
+                train_metrics["exact_accuracy"],
+                val_metrics["loss"],
+                val_metrics["exact_accuracy"],
+            )
+        else:
+            self.logger.info(
+                "epoch=%s train_loss=%.4f train_acc=%.4f",
+                epoch,
+                train_metrics["loss"],
+                train_metrics["exact_accuracy"],
+            )
 
     def test(self, test_loader: DataLoader | None = None) -> None:
         loader = test_loader or self.test_loader
@@ -341,7 +351,9 @@ class PreTrainer:
             return
 
         # Load best model if available
-        checkpoint_handler = self.handlers.get("checkpoint_best")
+        checkpoint_handler = self.handlers.get("checkpoint_best") or self.handlers.get(
+            "checkpoint_last"
+        )
         if checkpoint_handler and checkpoint_handler.last_checkpoint:
             checkpoint_path = checkpoint_handler.last_checkpoint
 


### PR DESCRIPTION
This pull request introduces support for test splits and evaluation in the training workflow, alongside a refactor of the transformer model's attention mechanism and some minor code and documentation improvements. The most significant changes are the addition of a `test` split to the configuration, corresponding updates to the trainer to support test evaluation and logging, and the replacement of PyTorch's built-in multi-head attention with a custom implementation.

**Test split and evaluation support:**

- Added a `test` split to `DataConfig` in `trainite/config/base.py`, allowing users to specify a test dataset in configuration. The README and project initialization logic were updated to reflect and support this change. [[1]](diffhunk://#diff-73352dfb97a0b9afb3ad346b22af2fdb5df6e72c73da6aa0df96d85c0a4c0cddR45) [[2]](diffhunk://#diff-ada0f955d81307b406b77a5ab5e7423974538138ae1ead8e4005cce3b61cd101L42-R49) [[3]](diffhunk://#diff-1e20c19b0f95a48591a0f35c025ef834b85ff6c4deaecb675a711f8499f1bf40L330-L337)
- Updated `PreTrainer` in `trainite/trainers/pretrainer.py` to build and use a test dataloader, attach test metrics, run test evaluation after training, and log results to TensorBoard. Added a `test` method to handle loading the best model and running evaluation. [[1]](diffhunk://#diff-8f40d97481e59dd82f8477965646f5d9517f80b514ebf0d45e17346dae39c1caR36) [[2]](diffhunk://#diff-8f40d97481e59dd82f8477965646f5d9517f80b514ebf0d45e17346dae39c1caR63-R68) [[3]](diffhunk://#diff-8f40d97481e59dd82f8477965646f5d9517f80b514ebf0d45e17346dae39c1caR95) [[4]](diffhunk://#diff-8f40d97481e59dd82f8477965646f5d9517f80b514ebf0d45e17346dae39c1caR172-R188) [[5]](diffhunk://#diff-8f40d97481e59dd82f8477965646f5d9517f80b514ebf0d45e17346dae39c1caR289-R295) [[6]](diffhunk://#diff-8f40d97481e59dd82f8477965646f5d9517f80b514ebf0d45e17346dae39c1caR324-R349) [[7]](diffhunk://#diff-8f40d97481e59dd82f8477965646f5d9517f80b514ebf0d45e17346dae39c1caR366-R368)

**Transformer model improvements:**

- Replaced the use of PyTorch's `nn.MultiheadAttention` with a custom `Attention` class in `trainite/models/transformer.py`, providing more direct control over masking and dropout. Updated the transformer block and model forward passes to use the new attention mechanism and handle padding masks correctly. [[1]](diffhunk://#diff-23286b30be7f6477ea835453fdb3dcc78f5fe95323349abe4f0c6ebf17fe04e8R27-R79) [[2]](diffhunk://#diff-23286b30be7f6477ea835453fdb3dcc78f5fe95323349abe4f0c6ebf17fe04e8L37-R90) [[3]](diffhunk://#diff-23286b30be7f6477ea835453fdb3dcc78f5fe95323349abe4f0c6ebf17fe04e8L49-R104) [[4]](diffhunk://#diff-23286b30be7f6477ea835453fdb3dcc78f5fe95323349abe4f0c6ebf17fe04e8R142-R150)

**Other improvements and fixes:**

- Removed the default `learning_rate` from `PreTrainerConfig` in `trainite/config/trainer.py` to defer learning rate specification elsewhere.
- Minor code cleanup and import reordering in `trainite/datasets/string_reverse.py`, and ensured special tokens are included in the character-to-id mapping. [[1]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L2-R3) [[2]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L30) [[3]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250R39-R41)