### PR TITLE
Add component README templates and render in init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,199 @@
 # Trainite
 
-**Trainite** is a cookiecutter-style toolbox for training language models with PyTorch-Ignite. It is designed for researchers who want to go from zero to a running training loop in minutes without fighting a framework's abstractions.
+**Trainite** is a cookiecutter toolbox for training language models with PyTorch-Ignite. Generate a clean, working project — model, dataset, config, trainer, entrypoint — and get out of the way. Zero to running training loop in minutes.
 
 ---
+
+## Quickstart
+
+```bash
+git clone <repo-url>
+cd trainite_prototype
+uv sync
+
+# Initialize a project from built-in components
+uv run trainite init my-experiment --model transformer --dataset string-reverse --trainer pretrainer
+
+cd my-experiment
+uv run python main.py config.yaml
+```
+
+---
+
 ## Design Overview
-### 1. The Registry System (`ComponentSpec`)
-Trainite uses a centralized registry (`trainite/config/registry.py`) to manage its built-in components. Each component (Model, Dataset, Trainer) is defined by a `ComponentSpec`:
 
-- **`implementation_path`**: Path to the source file used as a template.
-- **`config_cls`**: The Pydantic class defining the component's hyperparameters.
-- **`builder_symbol`**: The name of the factory function (e.g., `build_model`) that instantiates the component.
+### Cookiecutter, Not Framework
+`trainite init` generates real, readable Python files. You own them. No hidden imports, no sealed abstractions. Modify anything — model, dataset, train step, metrics — without touching the rest.
 
-This registry allows the CLI to dynamically discover and compose any combination of components during initialization.
+### Registry System
+Centralized registry (`trainite/config/registry.py`) manages built-in components via `ComponentSpec`:
 
-### 2. Dynamic Config Generation
-One of Trainite's core features is generating a **local, self-contained `config.py`** for each project. It achieves this using Python's `inspect` module:
+| Field | Purpose |
+|---|---|
+| `implementation_path` | Source file used as template |
+| `config_cls` | Pydantic class for hyperparameters |
+| `builder_symbol` | Factory function (e.g., `build_transformer_model`) |
+| `readme_template_path` | Per-component documentation template |
+| `collate_fn_symbol` | (Datasets only) Collate function for DataLoader |
 
-- When `trainite init` runs, it looks up the `config_cls` for the selected model, dataset, and trainer.
-- It uses **`inspect.getsource(cls)`** to extract the literal source code of these Pydantic models.
-- It then concatenates these definitions into a single `config.py` file and wraps them in a master `ProjectConfig` class.
+Registry enables CLI to dynamically discover and compose any combination of components.
 
-**Why?** This ensures the generated project has a fully typed, IDE-friendly configuration system without needing to import the `trainite` library at runtime.
+### Dynamic Config Generation
+When `trainite init` runs, it uses `inspect.getsource(cls)` to extract Pydantic model source code and inlines it into a local `config.py`. Result: fully typed, IDE-friendly configuration with zero runtime dependency on the `trainite` library.
 
-### 3. Template Adaptation Logic
-The CLI doesn't just copy files; it **refactors** them on the fly. In `trainite/cli/init.py`, the `_build_templates` function performs targeted string replacements:
+### Template Adaptation
+The CLI rewrites imports on the fly: `from trainite.config import ...` → `from config import ...`, and normalizes builder function references so `main.py` stays generic across architectures.
 
-- **Rewiring Imports**: Changes library-style imports (e.g., `from trainite.config import ...`) to local imports (`from config import ...`).
-- **Symbol Normalization**: It renames specific builder functions to generic names like `build_model` or `build_dataloaders` so that `main.py` can remain generic across different architectures.
+---
 
-### 4. Configuration Composition
-The generated `ProjectConfig` uses Pydantic's `Field(default_factory=...)` to compose the sub-configs:
+## Components
+
+### String Reverse Dataset
+
+Synthetic seq2seq task: given a random string, predict its reverse. Great for testing whether a model can learn structural transformation.
+
+- **Tokenizer**: Character-level (`CharTokenizer`), covers all printable ASCII. `<pad>`, `<bos>`, `<eos>`, `<unk>` special tokens.
+- **Format**: Prompt is `<bos> <sequence> <eos>`, target is `<sequence> <eos> <reversed> <eos>`. Prompt tokens masked from loss — model only learns on the reversed portion.
+- **Collation**: Dynamic padding. Inputs pad with `0`, labels pad with `-100`.
+
+| Config Key | Default | Notes |
+|---|---|---|
+| `size` | 256 | Number of samples |
+| `charset` | `"@alpha"` | `"@alpha"`, `"@digits"`, `"@universal"`, or custom string |
+| `min_seq_len` / `max_seq_len` | 1 / 16 | Variable-length mode (or use `seq_len` for fixed) |
+| `seed` | 42 | Reproducibility |
+
+### Transformer Model
+
+Standard decoder-only Transformer. Sinusoidal positional encoding, multi-head causal self-attention via `F.scaled_dot_product_attention`, GELU feedforward.
+
+- **Attention**: Single QKV projection, chunked into heads. Causal mask by default; combines with padding mask when present.
+- **Scaling**: Embeddings multiplied by `√hidden_size` before positional encoding (per the original paper).
+- **Vocab**: Auto-resolved from dataset if not provided in config. Must be ≥ dataset vocab size.
+
+| Config Key | Default | Notes |
+|---|---|---|
+| `hidden_size` | 64 | Embedding dimension |
+| `num_layers` | 2 | Transformer block count |
+| `num_heads` | 2 | Must divide `hidden_size` |
+| `feedforward_dim` | 128 | FFN hidden dimension |
+| `dropout` | 0.1 | Applied in attn, FFN, pos encoding |
+| `max_seq_len` | 128 | Positional encoding buffer size |
+
+### PreTrainer
+
+Batteries-included training loop on PyTorch-Ignite. Handles everything you don't want to write: engine wiring, checkpointing, early stopping, LR scheduling, and TensorBoard logging.
+
+- **LR schedule**: 10% warmup (0 → peak), 90% linear decay (peak → 0).
+- **Checkpointing**: Saves best model by validation accuracy + last model every epoch.
+- **Early stopping**: Patience of 3 epochs on validation loss.
+- **Metrics**: Masked cross-entropy loss, exact-match sequence accuracy.
+
+| Config Key | Default | Notes |
+|---|---|---|
+| `epochs` | 3 | Training epochs |
+| `log_every_steps` | 10 | Logging interval |
+| `grad_clip_norm` | None | Max gradient norm (disabled if None) |
+
+Output: `output/<run_name>/<timestamp>/` — config snapshot, log, best/last checkpoints, TensorBoard events.
+
+---
+
+## Config System (`trainite/config/`)
+
+Configuration is YAML → Pydantic → validated. Every component has a dedicated Pydantic model.
+
+**Hierarchy:**
+
+```
+ProjectConfig
+├── model: ComponentConfig          (TransformerModelConfig)
+├── optimizer: OptimizerConfig      (torch.optim.AdamW, lr, etc.)
+├── data: DataConfig
+│   ├── train: SplitConfig
+│   │   ├── dataset: ComponentConfig   (StringReverseDatasetConfig)
+│   │   └── dataloader: DataLoaderConfig
+│   ├── val: SplitConfig | None
+│   └── test: SplitConfig | None
+├── trainer: TrainerConfig          (PreTrainerConfig)
+├── output: OutputConfig            (root, run_name)
+├── seed: int
+└── device: str                     ("auto" | "cpu" | "cuda")
+```
+
+`ComponentConfig` uses `_target_` key for late binding: the string `"module.path.builder_function"` is resolved via `importlib`, enabling config-driven instantiation without hardcoded imports.
 
 ```python
-class ProjectConfig(BaseModel):
-    model: TransformerModelConfig = Field(default_factory=TransformerModelConfig)
-    dataset: StringReverseDatasetConfig = Field(default_factory=StringReverseDatasetConfig)
-    # ...
+# trainite/utils.py
+def instantiate(config: ComponentConfig, **kwargs) -> Any:
+    target_path = config._target_    # "trainite.models.transformer.build_transformer_model"
+    target_symbol = get_target(target_path)
+    return target_symbol(**config_params, **kwargs)
 ```
-This composition allows for a flat YAML structure that is both easy to read and strictly validated.
+
+`dump_config(config, path)` writes the full resolved config back to YAML for reproducibility.
 
 ---
 
-## Directory Structure
+## Templates (`trainite/templates/`)
 
-### Core Library (Prototype)
-```text
+Per-component documentation templates live in `trainite/templates/components/`. During `trainite init`, the CLI reads them and fills placeholders (`{{project_name}}`, `{{model_docs}}`, etc.) into the generated `README.md`.
+
+```
+trainite/templates/
+├── components/
+│   ├── datasets/string_reverse.md
+│   ├── models/transformer.md
+│   └── trainers/pretrainer.md
+└── project/
+    └── README.md          # Template for generated project README
+```
+
+The project README template (`README.md`) uses `{{model_docs}}`, `{{dataset_docs}}`, `{{trainer_docs}}` placeholders that get replaced with content from the component templates. This means generated projects get tailored documentation reflecting exactly which components were selected.
+
+---
+
+## Project Structure
+
+### Library source
+```
 trainite/
-├── cli/            # CLI implementation & template adaptation logic
-├── config/         # Pydantic schemas & the Component Registry
-├── datasets/       # Implementation templates for datasets
-├── models/         # Implementation templates for models
-└── trainers/       # Base training logic (Ignite Engines)
+├── cli/            # CLI: init command, template adaptation, import rewriting
+├── config/         # Pydantic schemas, ComponentSpec registry, config I/O
+├── datasets/       # Dataset implementations (string_reverse, ...)
+├── models/         # Model implementations (transformer, ...)
+├── trainers/       # Training loop (pretrainer)
+├── templates/      # Per-component docs, project README template
+├── main.py         # Library entrypoint (for direct prototyping)
+└── utils.py        # get_target, instantiate helpers
 ```
 
-### Generated Project Structure
-```text
-<project>/
-├── config.yaml     # End-user hyperparameter file
-├── config.py       # Generated Pydantic models (source-injected)
-├── model.py        # Adapted model architecture
-├── dataset.py      # Adapted dataset/dataloader logic
-├── trainer.py      # Adapted Ignite training loop
-└── main.py         # Static entrypoint
+### Generated project (`trainite init`)
 ```
+<project>/
+├── config.yaml     # YAML config — edit this
+├── config.py       # Generated Pydantic models (typed, IDE-friendly)
+├── models/         # Model architecture (your copy, editable)
+├── dataset/        # Dataset + collate (your copy, editable)
+├── trainer.py      # Training loop (your copy, editable)
+├── utils.py        # Config helpers
+├── main.py         # Entrypoint
+├── pyproject.toml  # Dependencies
+└── README.md       # Tailored to selected components
+```
+
+---
+
+## Extending
+
+| Layer | How |
+|---|---|
+| Model | Edit `model.py`, add new architecture class + builder |
+| Dataset | Edit `dataset.py`, add new Dataset subclass + collate |
+| Train step | Override `Pretrainer._train_step` or set `train_step` in config |
+| Metrics | Add Ignite metrics in `_attach_metrics` |
+| Handlers | Attach Ignite event handlers to `trainer.engine` |
+| Config | Add fields to Pydantic model + YAML — explicit, no magic |
 
 ---
 
@@ -74,35 +205,4 @@ cd trainite_prototype
 uv sync
 ```
 
----
-
-## Usage
-
-### 1. Initialize a Project
-```bash
-uv run trainite init my-experiment --model transformer --dataset string-reverse
-```
-
-### 2. Run Training
-```bash
-cd my-experiment
-uv run python main.py config.yaml
-```
-
----
-
-## Extending Trainite
-
-Since everything is a local file, extending is easy:
-- **Custom Model**: Modify `model.py`.
-- **Custom Data**: Modify `dataset.py`.
-- **Custom Metrics**: Attach new Ignite metrics in `trainer.py`'s `_attach_metrics`.
-- **Custom Handlers**: Use Ignite's event system in `trainer.py`.
-
----
-
-## Prototype specific files
-
-- `main.py`: Sample entrypoint running the library version directly.
-- `spec.md`: Design specification.
-- `config.yaml`: Default configuration.
+Dependencies: PyTorch, PyTorch-Ignite, Pydantic, PyYAML, OmegaConf, TensorBoard.

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -172,17 +172,33 @@ def _build_templates(
             )
         val = required_deps[dep] if dep in required_deps else other_deps[dep]
         final_deps.add(val)
+    model_docs = ""
+    if model_spec.readme_template_path:
+        model_docs = _render_template(PROJECT_ROOT / model_spec.readme_template_path)
+
+    dataset_docs = ""
+    if dataset_spec.readme_template_path:
+        dataset_docs = _render_template(
+            PROJECT_ROOT / dataset_spec.readme_template_path
+        )
+
+    trainer_docs = ""
+    if trainer_spec.readme_template_path:
+        trainer_docs = _render_template(
+            PROJECT_ROOT / trainer_spec.readme_template_path
+        )
+
     return {
         f"models/{model_spec.name}.py": _render_template(
-            model_spec.implementation_path,
+            PROJECT_ROOT / model_spec.implementation_path,
             model_spec.template_replacements,
         ),
         f"dataset/{dataset_spec.name}.py": _render_template(
-            dataset_spec.implementation_path,
+            PROJECT_ROOT / dataset_spec.implementation_path,
             dataset_spec.template_replacements,
         ),
         "trainer.py": _render_template(
-            trainer_spec.implementation_path,
+            PROJECT_ROOT / trainer_spec.implementation_path,
             trainer_spec.template_replacements,
         ),
         "utils.py": _render_template(
@@ -209,7 +225,15 @@ def _build_templates(
         ),
         "README.md": _render_template(
             PROJECT_ROOT / "trainite/templates/project/README.md",
-            [("{{project_name}}", project_name)],
+            [
+                ("{{project_name}}", project_name),
+                ("{{model_name}}", model_spec.name),
+                ("{{model_docs}}", model_docs),
+                ("{{dataset_name}}", dataset_spec.name),
+                ("{{dataset_docs}}", dataset_docs),
+                ("{{trainer_name}}", trainer_spec.name),
+                ("{{trainer_docs}}", trainer_docs),
+            ],
         ),
         "pyproject.toml": generate_uv_project(
             name=project_name,

--- a/trainite/config/registry.py
+++ b/trainite/config/registry.py
@@ -13,6 +13,7 @@ class ComponentSpec(BaseModel):
     implementation_path: Path
     config_cls: type
     implementation_symbol: str
+    readme_template_path: Path | None = None
     template_replacements: list[tuple[str, str]] = []
     dependencies: list[str] = []
 
@@ -37,6 +38,9 @@ MODEL_SPECS = {
         config_cls=TransformerModelConfig,
         implementation_symbol="TransformerModel",
         builder_symbol="build_transformer_model",
+        readme_template_path=Path(
+            "trainite/templates/components/models/transformer.md"
+        ),
     ),
 }
 
@@ -48,6 +52,9 @@ DATASET_SPECS = {
         implementation_symbol="StringReverseDataset",
         builder_symbol="build_string_reverse_dataset",
         collate_fn_symbol="collate_fn",
+        readme_template_path=Path(
+            "trainite/templates/components/datasets/string_reverse.md"
+        ),
     ),
 }
 
@@ -64,6 +71,9 @@ TRAINER_SPECS = {
             ),
             ("trainite.utils", "utils"),
         ],
+        readme_template_path=Path(
+            "trainite/templates/components/trainers/pretrainer.md"
+        ),
     ),
 }
 

--- a/trainite/templates/components/datasets/string_reverse.md
+++ b/trainite/templates/components/datasets/string_reverse.md
@@ -1,0 +1,106 @@
+# String Reverse dataset
+
+This dataset gives you a very small task: feed in a random character sequence, predict the reversed sequence.
+
+It is useful because it is easy to understand, fast to generate, and good for checking whether the model and training loop are wired correctly.
+
+## What each sample looks like
+
+Each example is built as a single prompt + answer sequence:
+
+```text
+<bos> abc <eos> cba <eos>
+```
+
+Training uses teacher forcing:
+
+- the input contains both the prompt and the answer
+- the labels mask out the prompt part with `-100`
+- loss is only computed on the reversed answer
+
+So the model is not asked to copy the input. It is asked to read the input, then produce the reversed text.
+
+## What the dataset returns
+
+Each item is a dictionary:
+
+```python
+{
+    "input_ids": Tensor,
+    "labels": Tensor,
+}
+```
+
+Use `collate_fn` to pad a batch:
+
+- inputs are padded with `0`
+- labels are padded with `-100`
+
+## Tokenizer
+
+The dataset uses a simple character tokenizer with these special tokens:
+
+- `0` = `<pad>`
+- `1` = `<bos>`
+- `2` = `<eos>`
+- `3` = `<unk>`
+
+It supports printable ASCII characters by default.
+
+## Config knobs
+
+### `size`
+How many examples to generate.
+
+### `charset`
+Which characters the random strings can use.
+
+Built-in presets:
+
+- `@universal` — all printable ASCII + space
+- `@alpha` — letters only
+- `@digits` — numbers only
+- `@alphanumeric` — letters and numbers
+
+You can also pass a custom string, for example `"abc123"`.
+
+### `seq_len`
+Use one fixed sequence length for every sample.
+
+### `min_seq_len` / `max_seq_len`
+Use a random length in this range.
+
+Do not set `seq_len` together with `min_seq_len` or `max_seq_len`.
+
+### `seed`
+Controls dataset generation so runs are repeatable.
+
+## Minimal config example
+
+```yaml
+data:
+  train:
+    dataset:
+      _target_: trainite.datasets.string_reverse.build_string_reverse_dataset
+      size: 512
+      charset: "@alpha"
+      min_seq_len: 2
+      max_seq_len: 12
+```
+
+## When to change this file
+
+Edit `trainite/datasets/string_reverse.py` if you want to:
+
+- change the tokenization rules
+- add or remove allowed characters
+- make the task longer or harder
+- change how padding or labels are built
+
+## Good starting rule
+
+If you only want to test the pipeline, keep the defaults and just change:
+
+- `size`
+- `charset`
+- `min_seq_len` / `max_seq_len`

--- a/trainite/templates/components/models/transformer.md
+++ b/trainite/templates/components/models/transformer.md
@@ -1,0 +1,100 @@
+# Transformer model
+
+This is the model that learns the string-reverse task.
+
+It is a decoder-only Transformer: given a sequence of token IDs, it predicts the next token at every position.
+
+## What goes in / out
+
+- **Input**: `input_ids` with shape `(batch, seq_len)`
+- **Output**: logits with shape `(batch, seq_len, vocab_size)`
+
+The trainer uses these logits with cross-entropy loss.
+
+## What the model is made of
+
+The model is small and standard:
+
+1. **Embedding**
+   Converts token IDs into vectors.
+2. **Positional encoding**
+   Adds token order information.
+3. **Transformer blocks**
+   Repeated attention + feedforward layers.
+4. **Final projection**
+   Maps hidden states back to vocabulary logits.
+
+## Practical notes
+
+### Padding
+Padding ID is `0`. The model ignores padded positions in attention.
+
+### Sequence length
+`max_seq_len` should be at least as long as your longest input sequence.
+
+### Hidden size and heads
+`hidden_size` must be divisible by `num_heads`.
+
+### Positional encoding
+`hidden_size` must be even because the positional encoding uses sine and cosine pairs.
+
+## Config knobs
+
+### `hidden_size`
+Size of the token embeddings and hidden states.
+
+Bigger values usually give more capacity, but cost more memory and time.
+
+### `num_layers`
+How many Transformer blocks to stack.
+
+More layers = more capacity, slower training.
+
+### `num_heads`
+How many attention heads to use.
+
+Choose a value that divides `hidden_size` cleanly.
+
+### `feedforward_dim`
+Size of the feedforward layer inside each block.
+
+A common choice is `2x` to `4x` of `hidden_size`.
+
+### `dropout`
+Dropout rate used in attention, feedforward layers, and positional encoding.
+
+### `max_seq_len`
+Maximum sequence length supported by positional encoding.
+
+## Minimal config example
+
+```yaml
+model:
+  _target_: trainite.models.transformer.build_transformer_model
+  hidden_size: 128
+  num_layers: 4
+  num_heads: 4
+  feedforward_dim: 256
+  dropout: 0.1
+  max_seq_len: 64
+```
+
+## When to change this file
+
+Edit `trainite/models/transformer.py` if you want to:
+
+- make the model wider or deeper
+- swap attention or feedforward behavior
+- change how padding is handled
+- add caching, rotary embeddings, or other sequence features
+
+## Good starting rule
+
+If the dataset is tiny, start with a small model:
+
+- `hidden_size=64`
+- `num_layers=2`
+- `num_heads=2`
+- `feedforward_dim=128`
+
+If training is stable and the model underfits, scale up from there.

--- a/trainite/templates/components/trainers/pretrainer.md
+++ b/trainite/templates/components/trainers/pretrainer.md
@@ -1,0 +1,122 @@
+# PreTrainer
+
+`PreTrainer` is the default training loop for this project.
+
+It is built on PyTorch-Ignite and already handles the things you usually want on day one:
+
+- training and evaluation loops
+- optimizer setup
+- learning-rate warmup + decay
+- checkpoints
+- early stopping
+- TensorBoard logging
+
+## What it expects
+
+`PreTrainer` works with a model that returns logits shaped like:
+
+```python
+(batch, seq_len, vocab_size)
+```
+
+and a batch that looks like:
+
+```python
+{
+    "input_ids": Tensor,
+    "labels": Tensor,
+}
+```
+
+It uses cross-entropy loss and ignores label value `-100`.
+
+## What happens during training
+
+For each batch:
+
+1. move batch to device
+2. run forward pass
+3. compute cross-entropy loss
+4. backpropagate
+5. clip gradients if `grad_clip_norm` is set
+6. step optimizer
+
+At the end of each epoch it also runs evaluation on:
+
+- training data
+- validation data, if present
+- test data, if present
+
+## Logging and checkpoints
+
+`PreTrainer` saves a run directory like this:
+
+```text
+output/<run_name>/<timestamp>/
+```
+
+Inside it you get:
+
+- `config.yaml`
+- `output.log`
+- `last_*` checkpoint
+- `best_*` checkpoint if validation exists
+- TensorBoard logs
+
+## Config knobs
+
+### `epochs`
+How many full passes over the training data to run.
+
+### `log_every_steps`
+How often to print training updates.
+
+### `grad_clip_norm`
+If set, gradients are clipped before the optimizer step.
+
+This can help when training becomes unstable.
+
+## What to tweak first
+
+If you are just getting started, the usual first changes are:
+
+- `epochs`
+- `log_every_steps`
+- `grad_clip_norm`
+- optimizer settings in `config.yaml`
+
+## If you want to customize behavior
+
+Edit `trainite/trainers/pretrainer.py` if you want to:
+
+- change how loss is computed
+- add gradient accumulation
+- add new metrics
+- change checkpoint rules
+- change validation frequency
+- change logging behavior
+
+The main places to look are:
+
+- `_train_step`
+- `_eval_step`
+- `_attach_metrics`
+- `_attach_handlers`
+
+## Minimal config example
+
+```yaml
+trainer:
+  epochs: 10
+  log_every_steps: 20
+  grad_clip_norm: 1.0
+```
+
+## Good starting rule
+
+If the run fails or looks unstable, check these first:
+
+- input and label shapes match
+- `vocab_size` is large enough for the dataset
+- `max_seq_len` is long enough
+- learning rate is not too high

--- a/trainite/templates/project/README.md
+++ b/trainite/templates/project/README.md
@@ -33,22 +33,18 @@ Trainite is a toolbox for training language models with PyTorch-Ignite. This pro
    uv run tensorboard --logdir outputs
    ```
 
+## Components
+
+### Model: {{model_name}}
+{{model_docs}}
+
+### Dataset: {{dataset_name}}
+{{dataset_docs}}
+
+### Trainer: {{trainer_name}}
+{{trainer_docs}}
+
 ## Customization
-
-### Modifying the Model
-Edit the files in `models/`. You can change the architecture, add new layers, or change how the loss is calculated if it's part of the model.
-
-### Using Your Own Data
-Update the dataset factory and `Dataset` class in `dataset/`. In `config.yaml`, the `data` section allows you to configure `train`, `val` and `test` splits separately. Each split contains:
-- `dataset`: Configuration for the dataset builder.
-- `dataloader`: Parameters for the PyTorch DataLoader (batch size, shuffle, num_workers, etc.).
-
-If you omit the `val` section, the trainer will fall back to using the `train` configuration for validation (with a warning).
-
-If you omit the `test` section, the trainer will skip the testing phase after training (with a warning).
-
-### Custom Training Logic
-If you need to change the training loop (e.g., add gradient clipping, custom logging, or a different optimization step), edit `trainer.py`. You can override methods of the `PreTrainer` (or `RLTrainer`) class.
 
 ### Adding Configuration Parameters
 1. Add the parameter to `config.yaml`.


### PR DESCRIPTION
This pull request significantly enhances Trainite's documentation system and project generation process. The main improvements are the introduction of per-component documentation templates for models, datasets, and trainers, and their automatic inclusion in generated project READMEs. Additionally, the registry system is updated to reference these documentation templates, and the CLI is refactored to render and inject them during project initialization. These changes make generated projects much more informative and tailored to the selected components.

**Documentation system enhancements:**

* Added `readme_template_path` to the `ComponentSpec` registry for models, datasets, and trainers, allowing each component to reference its own documentation template. [[1]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bR16) [[2]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bR41-R43) [[3]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bR55-R57) [[4]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bR74-R76)
* Created per-component documentation templates: `trainite/templates/components/models/transformer.md`, `trainite/templates/components/datasets/string_reverse.md`, and `trainite/templates/components/trainers/pretrainer.md`. These files provide detailed, user-friendly explanations of each component's usage, configuration, and extension points. [[1]](diffhunk://#diff-7ef2a80f22f1bd0d768bd1ea42debfbcfb632aeca48d57e56f513177d203e100R1-R106) [[2]](diffhunk://#diff-9b0453f96c11a26107f0eb008df3692b4bcef284a14f3500971db9c6c1b63b57R1-R100) [[3]](diffhunk://#diff-95248d14d5e5c6362e8aa607db601e02f75e60b0e2e0b7023801e7f70b348cdbR1-R122)

**Project generation improvements:**

* Updated the CLI (`trainite/cli/init.py`) to render and inject component documentation into the generated project's `README.md`, using the new template paths and placeholder replacement logic. [[1]](diffhunk://#diff-1e20c19b0f95a48591a0f35c025ef834b85ff6c4deaecb675a711f8499f1bf40R175-R201) [[2]](diffhunk://#diff-1e20c19b0f95a48591a0f35c025ef834b85ff6c4deaecb675a711f8499f1bf40L212-R236)
* Refactored the main `README.md` to explain the new documentation system, clarify project structure, and provide clearer quickstart and extension instructions.