### PR TITLE
Use ValueError instead of AssertionError and match error messages

### DIFF
--- a/tests/datasets/string_reverse_test.py
+++ b/tests/datasets/string_reverse_test.py
@@ -129,10 +129,6 @@ def test_collate_fn():
 
 
 def test_build_string_reverse_dataset():
-    dataset = build_string_reverse_dataset(size=5)
-    assert isinstance(dataset, StringReverseDataset)
-    assert len(dataset) == 5
-
     dataset = build_string_reverse_dataset(size=5, seq_len=3)
     assert isinstance(dataset, StringReverseDataset)
     assert len(dataset) == 5
@@ -142,25 +138,26 @@ def test_build_string_reverse_dataset():
     assert len(dataset) == 5
 
     with pytest.raises(
-        ValueError, match="Cannot specify both seq_len and min_seq_len/max_seq_len."
+        ValueError,
+        match="Cannot specify both seq_len and min_seq_len/max_seq_len.",
     ):
         build_string_reverse_dataset(size=5, seq_len=3, min_seq_len=1, max_seq_len=5)
 
     with pytest.raises(
         ValueError,
-        match="At least one of seq_len or min_seq_len/max_seq_len must be specified.",
+        match="Must specify either seq_len or both min_seq_len and max_seq_len.",
     ):
         build_string_reverse_dataset(size=5)
 
     with pytest.raises(
         ValueError,
-        match="At least one of seq_len or min_seq_len/max_seq_len must be specified.",
+        match="Must specify either seq_len or both min_seq_len and max_seq_len.",
     ):
         build_string_reverse_dataset(size=5, min_seq_len=1)
 
     with pytest.raises(
         ValueError,
-        match="At least one of seq_len or min_seq_len/max_seq_len must be specified.",
+        match="Must specify either seq_len or both min_seq_len and max_seq_len.",
     ):
         build_string_reverse_dataset(size=5, max_seq_len=1)
 

--- a/tests/models/transformer_test.py
+++ b/tests/models/transformer_test.py
@@ -24,7 +24,7 @@ def test_positional_encoding():
     d_model = 15
     max_len = 32
     with pytest.raises(
-        AssertionError, match="d_model must be even for sinusoidal positional encoding"
+        ValueError, match="d_model must be even for sinusoidal positional encoding."
     ):
         PositionalEncoding(d_model, max_len)
 
@@ -48,9 +48,7 @@ def test_attention():
     assert output.shape == x.shape
 
     # Non-divisible embed_dim should raise an assertion error
-    with pytest.raises(
-        ValueError, match="d_model must be even for sinusoidal positional encoding"
-    ):
+    with pytest.raises(ValueError, match="embed_dim must be divisible by num_heads."):
         Attention(15, 2)
 
 

--- a/trainite/models/transformer.py
+++ b/trainite/models/transformer.py
@@ -10,7 +10,7 @@ class PositionalEncoding(nn.Module):
         self.dropout = nn.Dropout(p=dropout)
 
         if d_model % 2 != 0:
-            raise ValueError("d_model must be even for sinusoidal positional encoding")
+            raise ValueError("d_model must be even for sinusoidal positional encoding.")
 
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
@@ -33,9 +33,8 @@ class Attention(nn.Module):
         self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.head_dim = embed_dim // num_heads
-        assert self.num_heads * self.head_dim == self.embed_dim, (
-            "embed_dim must be divisible by num_heads"
-        )
+        if not self.num_heads * self.head_dim == self.embed_dim:
+            raise ValueError("embed_dim must be divisible by num_heads.")
         self.qkv_projection = nn.Linear(embed_dim, embed_dim * 3, bias=False)
         self.out = nn.Linear(embed_dim, embed_dim, bias=False)
         self.dropout = nn.Dropout(p=dropout)


### PR DESCRIPTION
This pull request focuses on improving error handling and test clarity for the transformer model and dataset utilities. The key changes involve replacing assertion-based errors with explicit exceptions, updating error messages for consistency, and ensuring that tests accurately reflect the new error handling behavior.

**Model error handling improvements:**

* Changed assertion-based validation in the `Attention` class constructor to raise a `ValueError` if `embed_dim` is not divisible by `num_heads`, with a clearer error message. (`trainite/models/transformer.py`)
* Updated the `PositionalEncoding` class to raise a `ValueError` with a consistent message if `d_model` is not even. (`trainite/models/transformer.py`)

**Test updates for new error handling:**

* Modified tests in `tests/models/transformer_test.py` to expect `ValueError` (instead of `AssertionError`) and to match the new, more precise error messages for both `PositionalEncoding` and `Attention` classes. [[1]](diffhunk://#diff-6f82c08d9b763ae03bec58afcb3a2855191b40da55e2902ac0ea2268d754a140L27-R27) [[2]](diffhunk://#diff-6f82c08d9b763ae03bec58afcb3a2855191b40da55e2902ac0ea2268d754a140L51-R51)
* Updated dataset tests in `tests/datasets/string_reverse_test.py` to expect new error messages when incorrect arguments are provided to `build_string_reverse_dataset`, and removed a redundant test case. [[1]](diffhunk://#diff-c2f4f8b4321a41e2c5a0e98a2f02dcb6035a6ab905de64800706b537c137bcf4L132-L135) [[2]](diffhunk://#diff-c2f4f8b4321a41e2c5a0e98a2f02dcb6035a6ab905de64800706b537c137bcf4L145-R160)