### PR TITLE
Use questionary for CLI prompts and update deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "omegaconf>=2.3.0",
     "tomlkit>=0.15.0",
     "packaging>=26.2",
+    "questionary>=2.1.1",
 ]
 
 

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -5,6 +5,7 @@ import textwrap
 from pathlib import Path
 from typing import Iterable, Sequence
 
+import questionary
 import tomlkit
 from packaging.requirements import Requirement
 
@@ -49,15 +50,21 @@ def _render_class_source(cls: type) -> str:
 
 
 def _prompt_text(prompt: str, default: str) -> str:
-    value = input(f"{prompt} [{default}]: ").strip()
-    return value or default
+    result = questionary.text(prompt, default=default).ask()
+    if result is None:
+        raise SystemExit(0)
+    return result.strip() or default
 
 
 def _prompt_choice(prompt: str, choices: Sequence[str], default: str) -> str:
-    selected = _prompt_text(f"{prompt} ({' / '.join(choices)})", default)
-    if selected not in choices:
-        raise SystemExit(f"Unsupported choice: {selected}")
-    return selected
+    result = questionary.select(
+        prompt,
+        choices=choices,
+        default=default,
+    ).ask()
+    if result is None:
+        raise SystemExit(0)
+    return result
 
 
 def _project_directory(raw_project_dir: str, force: bool) -> Path:
@@ -359,9 +366,9 @@ def init_project(args: argparse.Namespace) -> None:
     for filename, content in templates.items():
         _write_file(project_dir / filename, content, args.force)
 
-    print(f"Generated starter project in {project_dir}")
-    for filename in ["config.yaml", *templates]:
-        print(f"- {filename}")
+    print("\n✔ Generated config.yaml")
+    for filename in templates:
+        print(f"✔ Generated {filename}")
 
 
 def main(argv: Sequence[str] | None = None) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -838,6 +838,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.35.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1118,6 +1130,18 @@ wheels = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1294,6 +1318,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "questionary" },
     { name = "tomlkit" },
 ]
 
@@ -1321,6 +1346,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=26.2" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pyyaml" },
+    { name = "questionary", specifier = ">=2.1.1" },
     { name = "tomlkit", specifier = ">=0.15.0" },
 ]
 
@@ -1398,6 +1424,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request improves the user experience of the project initialization CLI by replacing basic input prompts with the more user-friendly `questionary` library and enhancing output messages. The most important changes are:

**User Input Enhancements:**

* Replaced standard `input()` prompts in `_prompt_text` and `_prompt_choice` with `questionary`'s interactive prompts for better usability and validation. (`trainite/cli/init.py`)
* Added `questionary>=2.1.1` as a dependency in `pyproject.toml`.

**Output Improvements:**

* Updated the project generation output to use clearer, more visually distinct messages with checkmarks for each generated file. (`trainite/cli/init.py`)

**Imports Update:**

* Imported `questionary` in `trainite/cli/init.py` to enable the new prompt functionality.