### PR TITLE
Fixed max catching for max_attempts

### DIFF
--- a/tests/datasets/string_reverse_test.py
+++ b/tests/datasets/string_reverse_test.py
@@ -183,3 +183,16 @@ def test_config_build_string_reverse_dataset():
     assert "labels" in batch
     assert batch["input_ids"].shape[0] == dataloader_conf.batch_size
     assert batch["input_ids"].shape == batch["labels"].shape
+
+
+def test_string_reverse_dataset_size_capping_and_warning():
+    # Vocab size is 3 ('a', 'b', 'c'), max possible for length 1 is 3.
+    # Requesting per_seq_size=10 should trigger a warning and cap the size at 3.
+    with pytest.warns(
+        UserWarning,
+        match="Requested 10 unique sequences for seq_len=1 but only 3 could be generated",
+    ):
+        dataset = StringReverseDataset(
+            per_seq_size=10, min_seq_len=1, max_seq_len=1, charset="abc", seed=42
+        )
+    assert len(dataset) == 3

--- a/trainite/datasets/string_reverse.py
+++ b/trainite/datasets/string_reverse.py
@@ -151,11 +151,10 @@ class StringReverseDataset(Dataset):
             target = min(per_seq_size, max_possible_combinations)
 
             # Safety cap to avoid infinite loops when the space is small
+            attempts = 0
             max_attempts = target * 20
 
-            while (
-                len(unique_sequences) < target and len(unique_sequences) < max_attempts
-            ):
+            while len(unique_sequences) < target and attempts < max_attempts:
                 indices = torch.randint(
                     low=0,
                     high=len(self.valid_token_ids),
@@ -164,6 +163,7 @@ class StringReverseDataset(Dataset):
                 )
                 seq_tuple = tuple(self.valid_token_ids_tensor[indices].tolist())
                 unique_sequences.add(seq_tuple)
+                attempts += 1
 
             if len(unique_sequences) < per_seq_size:
                 warnings.warn(


### PR DESCRIPTION
The PR fixes a bug in the dataset code where `unique_sequences` was being used to keep track of our counts in the while loop incorrectly. I have added a seperate variable `attempts` to keep track of all of our attempts (even the duplicate ones) so we can reach `max_attempts` if needed. Also added a test for it