### PR TITLE
Generalize decoder trainer: move inference prompt format into the transform

### DIFF
--- a/tests/trainers/pretrainer_test.py
+++ b/tests/trainers/pretrainer_test.py
@@ -34,6 +34,8 @@ def create_trainer_from_config(config: ProjectConfig) -> PreTrainer:
     vocab_size = resolve_vocab_size(tokenizer, config.model)
     model = build_model(config.model, tokenizer, vocab_size, device)
     optimizer = instantiate(config.optimizer, params=model.parameters())
+    ds = train_loader.dataset
+    ds = ds.dataset if isinstance(ds, torch.utils.data.Subset) else ds
     return PreTrainer(
         config=config,
         model=model,
@@ -42,7 +44,7 @@ def create_trainer_from_config(config: ProjectConfig) -> PreTrainer:
         val_loader=val_loader,
         test_loader=test_loader,
         preprocessor=tokenizer,
-        # vocab_size=vocab_size,
+        prompt_transform=getattr(ds, "transform", None),
     )
 
 
@@ -166,6 +168,19 @@ class GenerativeModel(SimpleModel):
         return torch.cat([input_ids, dummy_new], dim=-1)
 
 
+class DummyTransform:
+    """Passthrough transform that also supplies a prompt format for inference."""
+
+    def __init__(self, tokenizer=None):
+        self.tokenizer = tokenizer
+
+    def __call__(self, sample):
+        return sample
+
+    def build_prompt(self, sample):
+        return [self.tokenizer.bos_token_id] + self.tokenizer.encode(sample["source"]) + [self.tokenizer.sep_token_id]
+
+
 class GenerativeDataset(SimpleDataset):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -238,7 +253,7 @@ def project_config(temp_run_dir):
     )
 
 
-def test_flatten_loss():
+def test_flatten():
     # Mock some data
     logits = torch.randn(2, 3, 5)  # B=2, S=3, V=5
     targets = torch.tensor([[1, 2, -100], [0, -100, 3]])
@@ -247,23 +262,7 @@ def test_flatten_loss():
     trainer.loss_fn = nn.CrossEntropyLoss(ignore_index=-100)
 
     output = {"logits": logits, "targets": targets}
-    flat_logits, flat_targets = trainer._flatten_loss(output)
-
-    assert flat_logits.shape == (4, 5)  # 6 tokens total, 2 are masked
-    assert flat_targets.shape == (4,)
-    assert (flat_targets == torch.tensor([1, 2, 0, 3])).all()
-
-
-def test_flatten_accuracy():
-    # Mock some data
-    logits = torch.randn(2, 3, 5)  # B=2, S=3, V=5
-    targets = torch.tensor([[1, 2, -100], [0, -100, 3]])
-
-    trainer = PreTrainer.__new__(PreTrainer)
-    trainer.loss_fn = nn.CrossEntropyLoss(ignore_index=-100)
-
-    output = {"logits": logits, "targets": targets}
-    flat_logits, flat_targets = trainer._flatten_accuracy(output)
+    flat_logits, flat_targets = trainer._flatten(output)
 
     assert flat_logits.shape == (4, 5)  # 6 tokens total, 2 are masked
     assert flat_targets.shape == (4,)
@@ -587,39 +586,24 @@ def test_pretrainer_dataloader_class_collate_fn(project_config):
     assert isinstance(trainer.train_loader.collate_fn.tokenizer, DummyTokenizer)
 
 
+# Inference param validation now lives on PreTrainerConfig (Field(gt=0)), so bad
+# values (non-positive or non-int) are rejected at config construction.
 @pytest.mark.parametrize(
-    "epochs, tokens, samples",
+    "kwargs",
     [
-        (0, 32, 4),  # Invalid epochs
-        (1, 0, 4),  # Invalid tokens
-        (1, 32, 0),  # Invalid samples
-        (-1, 32, 4),  # Negative epochs
-        (1, -1, 4),  # Negative tokens
-        (1, 32, -1),  # Negative samples
+        {"inference_every_epochs": 0},
+        {"max_inference_new_tokens": 0},
+        {"inference_num_samples": 0},
+        {"inference_every_epochs": -1},
+        {"max_inference_new_tokens": -1},
+        {"inference_num_samples": -1},
+        {"inference_every_epochs": 2.5},
+        {"inference_num_samples": "0.3"},
     ],
 )
-def test_setup_inference_invalid_inference_params(project_config, epochs, tokens, samples):
-    project_config.trainer.inference_every_epochs = epochs
-    project_config.trainer.max_inference_new_tokens = tokens
-    project_config.trainer.inference_num_samples = samples
-    with pytest.raises(ValueError, match="Inference logging parameters must be greater than 0"):
-        create_trainer_from_config(project_config)
-
-
-@pytest.mark.parametrize(
-    "epochs, tokens, samples",
-    [
-        (2.5, 32, 4),  # Invalid type epochs
-        (1, True, 4),  # Invalid type tokens
-        (1, 32, "0.3"),  # Invalid type samples
-    ],
-)
-def test_setup_inference_invalid_inference_type_params(project_config, epochs, tokens, samples):
-    project_config.trainer.__dict__["inference_every_epochs"] = epochs
-    project_config.trainer.__dict__["max_inference_new_tokens"] = tokens
-    project_config.trainer.__dict__["inference_num_samples"] = samples
-    with pytest.raises(TypeError, match="Inference logging parameters must be integers."):
-        create_trainer_from_config(project_config)
+def test_invalid_inference_params_rejected(kwargs):
+    with pytest.raises(ValidationError):
+        PreTrainerConfig(**kwargs)
 
 
 def test_setup_inference_invalid_dataset_items(project_config):
@@ -670,18 +654,21 @@ def test_setup_inference_and_log_success(project_config, temp_run_dir):
         vocab_size=10,
         hidden_size=8,
     )
+    transform = cc("tests.trainers.pretrainer_test.DummyTransform")
     project_config.data.train.dataset = cc(
         "tests.trainers.pretrainer_test.GenerativeDataset",
         size=16,
         seq_len=4,
         vocab_size=10,
     )
+    project_config.data.train.transform = transform
     project_config.data.val.dataset = cc(
         "tests.trainers.pretrainer_test.GenerativeDataset",
         size=8,
         seq_len=4,
         vocab_size=10,
     )
+    project_config.data.val.transform = transform
     trainer = create_trainer_from_config(project_config)
     assert trainer.max_inference_new_tokens == 32
     trainer.run()

--- a/trainite/datasets/string_reverse.py
+++ b/trainite/datasets/string_reverse.py
@@ -128,24 +128,30 @@ class PromptCompletionTransform:
         self.tokenizer = tokenizer
         self.ignore_index = ignore_index
 
+    def build_prompt(self, sample: dict[str, str]) -> list[int]:
+        """Token ids for the generation prompt: [bos] + source + [sep] (no target)."""
+        bos = self.tokenizer.bos_token_id
+        sep = self.tokenizer.sep_token_id
+        source_tokens = self.tokenizer(sample["source"], add_special_tokens=False)["input_ids"]
+        return [bos] + source_tokens + [sep]
+
     def __call__(self, sample: dict[str, str]) -> dict[str, torch.Tensor]:
         source = sample["source"]
         target = sample["target"]
 
-        sep = self.tokenizer.sep_token_id
-        bos = self.tokenizer.bos_token_id
         eos = self.tokenizer.eos_token_id
 
-        source_tokens = self.tokenizer(source, add_special_tokens=False)["input_ids"]
+        prompt_ids = self.build_prompt(sample)
         target_tokens = self.tokenizer(target, add_special_tokens=False)["input_ids"]
 
-        combined_input_ids = [bos] + source_tokens + [sep] + target_tokens + [eos]
+        combined_input_ids = prompt_ids + target_tokens + [eos]
 
         input_ids = torch.tensor(combined_input_ids[:-1], dtype=torch.long)
         labels = torch.tensor(combined_input_ids[1:], dtype=torch.long)
 
-        # Apply labels masking for the prompt tokens
-        labels[: len(source_tokens) + 1] = self.ignore_index
+        # Mask the prompt portion of the (shifted) labels. labels = combined[1:],
+        # so the prompt spans len(prompt_ids) - 1 leading positions.
+        labels[: len(prompt_ids) - 1] = self.ignore_index
 
         attention_mask = torch.ones(len(input_ids), dtype=torch.long)
 

--- a/trainite/shared/main.py
+++ b/trainite/shared/main.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import torch
 from torch import nn
-from torch.utils.data import DataLoader, Dataset, random_split
+from torch.utils.data import DataLoader, Dataset, Subset, random_split
 
 from trainite.datasets.transformed import TransformedDataset
 from trainite.shared.utils import get_target, instantiate, load_config
@@ -181,6 +181,11 @@ def main() -> None:
 
     optimizer = instantiate(config.optimizer, params=model.parameters())
 
+    # The transform owns the prompt format; hand it to the trainer for inference logging.
+    ds = train_loader.dataset
+    ds = ds.dataset if isinstance(ds, Subset) else ds
+    prompt_transform = getattr(ds, "transform", None)
+
     trainer = PreTrainer(
         config=config,
         model=model,
@@ -189,6 +194,7 @@ def main() -> None:
         val_loader=val_loader,
         test_loader=test_loader,
         preprocessor=tokenizer,
+        prompt_transform=prompt_transform,
     )
     trainer.run()
 

--- a/trainite/trainers/pretrainer.py
+++ b/trainite/trainers/pretrainer.py
@@ -361,7 +361,7 @@ class PreTrainer:
         if not hasattr(tokenizer, "decode") or not callable(tokenizer):
             raise ValueError("Tokenizer must be callable and implement 'decode' method for inference logging.")
 
-        # Validate active loaders yield source/target
+        # Validate active loaders
         self._validate_dataloader_for_inference(self.train_loader, "Train")
         if self.val_loader is not None:
             self._validate_dataloader_for_inference(self.val_loader, "Val")
@@ -380,7 +380,7 @@ class PreTrainer:
         pad_token_id = getattr(self.tokenizer, "pad_token_id", 0)
 
         dataset = loader.dataset
-        total_samples = len(dataset)
+        total_samples = len(dataset)  # type: ignore
         num_samples = min(self.inference_num_samples, total_samples)
 
         # Build generation prompts via the dataset's transform (validated in _setup_inference).

--- a/trainite/trainers/pretrainer.py
+++ b/trainite/trainers/pretrainer.py
@@ -40,10 +40,10 @@ class PreTrainerConfig(BaseModel):
     epochs: int = Field(default=3, gt=0)
     log_every_steps: int = Field(default=10, gt=0)
     early_stopping_patience: int | None = Field(default=3, gt=0)
-    # Inference logging — validated at runtime in _setup_inference
-    inference_every_epochs: int | None = Field(default=None)
-    inference_num_samples: int = Field(default=5)
-    max_inference_new_tokens: int = Field(default=16)
+    # Inference logging
+    inference_every_epochs: int | None = Field(default=None, gt=0)
+    inference_num_samples: int = Field(default=5, gt=0)
+    max_inference_new_tokens: int = Field(default=16, gt=0)
     grad_clip_norm: float | None = Field(default=None, gt=0.0)
 
 
@@ -69,11 +69,13 @@ class PreTrainer:
         train_loader: DataLoader,
         val_loader: DataLoader,
         test_loader: DataLoader | None = None,
+        prompt_transform: Any = None,
     ) -> None:
         self.logger: logging.Logger = setup_logger("trainer", level=logging.INFO)
         torch.manual_seed(config.seed)
         self.config: ProjectConfig = config
-        self.tokenizer: Any = preprocessor
+        self.tokenizer = preprocessor
+        self.prompt_transform = prompt_transform
         self.device: str | torch.device = self._resolve_device()
         self.epochs: int = config.trainer.epochs
         self.grad_clip_norm: float | None = getattr(config.trainer, "grad_clip_norm", None)
@@ -113,13 +115,7 @@ class PreTrainer:
         run_dir.mkdir(parents=True, exist_ok=True)
         return run_dir
 
-    def _flatten_loss(self, output: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
-        logits = output["logits"].reshape(-1, output["logits"].size(-1))
-        targets = output["targets"].reshape(-1)
-        mask = targets != self.loss_fn.ignore_index
-        return logits[mask], targets[mask]
-
-    def _flatten_accuracy(self, output: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+    def _flatten(self, output: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         logits = output["logits"].reshape(-1, output["logits"].size(-1))
         targets = output["targets"].reshape(-1)
         mask = targets != self.loss_fn.ignore_index
@@ -168,8 +164,8 @@ class PreTrainer:
             ("val", self.val_evaluator),
             ("test", self.test_evaluator),
         ]:
-            loss = Loss(self.loss_fn, output_transform=self._flatten_loss)
-            token_acc = Accuracy(output_transform=self._flatten_accuracy)
+            loss = Loss(self.loss_fn, output_transform=self._flatten)
+            token_acc = Accuracy(output_transform=self._flatten)
 
             loss.attach(evaluator, "loss")
             token_acc.attach(evaluator, "token_accuracy")
@@ -354,60 +350,40 @@ class PreTrainer:
         if len(dataset) == 0:
             raise ValueError(f"{name} dataset is empty. Cannot perform inference logging.")
         dataset = dataset.dataset if isinstance(dataset, Subset) else dataset
-        item = dataset[0]  # type: ignore
+        item = dataset[0]
         if not isinstance(item, dict):
             raise ValueError(f"{name} dataset items must be dicts with 'source' and 'target' keys.")
         if "source" not in item or "target" not in item:
             raise ValueError(f"{name} dataset items must contain 'source' and 'target' keys. Got: {list(item.keys())}")
 
-    def _setup_inference(self) -> object:
-        inference_params = (
-            self.inference_every_epochs,
-            self.inference_num_samples,
-            self.max_inference_new_tokens,
-        )
-        if any((not isinstance(param, int) or isinstance(param, bool)) for param in inference_params):
-            raise TypeError(
-                f"Inference logging parameters must be integers.\n"
-                f"Got inference_every_epochs={self.inference_every_epochs}, "
-                f"inference_num_samples={self.inference_num_samples}, "
-                f"max_inference_new_tokens={self.max_inference_new_tokens}"
-            )
-
-        if any(param <= 0 for param in inference_params):
-            raise ValueError(
-                f"Inference logging parameters must be greater than 0.\n"
-                f"Got inference_every_epochs={self.inference_every_epochs}, "
-                f"inference_num_samples={self.inference_num_samples}, "
-                f"max_inference_new_tokens={self.max_inference_new_tokens}"
-            )
-
+    def _setup_inference(self) -> None:
         tokenizer: Any = self.tokenizer
         if not hasattr(tokenizer, "decode") or not callable(tokenizer):
             raise ValueError("Tokenizer must be callable and implement 'decode' method for inference logging.")
 
-        # Validate active loaders
+        # Validate active loaders yield source/target
         self._validate_dataloader_for_inference(self.train_loader, "Train")
         if self.val_loader is not None:
             self._validate_dataloader_for_inference(self.val_loader, "Val")
         if self.test_loader is not None:
             self._validate_dataloader_for_inference(self.test_loader, "Test")
 
-    def _log_inference(self, engine: Engine, loader: DataLoader, name: str) -> None:
-        tokenizer: Any = self.tokenizer
+        # The transform supplies the prompt format (source -> token ids)
+        if self.prompt_transform is None or not hasattr(self.prompt_transform, "build_prompt"):
+            raise ValueError(
+                "Inference logging requires the dataset's transform to define build_prompt(sample) -> list[int]."
+            )
 
+    def _log_inference(self, engine: Engine, loader: DataLoader, name: str) -> None:
         self.logger.info(f"Epoch {engine.state.epoch}: Running inference on {name} samples...")
 
-        eos_token_id = self.tokenizer.eos_token_id
-        sep_token_id = self.tokenizer.sep_token_id
-        bos_token_id = self.tokenizer.bos_token_id
         pad_token_id = getattr(self.tokenizer, "pad_token_id", 0)
 
         dataset = loader.dataset
-        total_samples = len(dataset)  # type: ignore
+        total_samples = len(dataset)
         num_samples = min(self.inference_num_samples, total_samples)
 
-        # Extract prompt IDs via dataset.get_item_inference (validated in _setup_inference).
+        # Build generation prompts via the dataset's transform (validated in _setup_inference).
         prompt_ids_list: list[torch.Tensor] = []
         prompt_attn_list: list[torch.Tensor] = []
         targets: list[str] = []
@@ -417,16 +393,14 @@ class PreTrainer:
             source = item["source"]
             target = item["target"]
 
-            input_ids = tokenizer(source, add_special_tokens=False)["input_ids"]
-            input_ids = torch.tensor([bos_token_id] + input_ids + [sep_token_id], dtype=torch.long)
+            input_ids = torch.tensor(self.prompt_transform.build_prompt(item), dtype=torch.long)
             attention_mask = torch.ones_like(input_ids, dtype=torch.long)
 
             prompt_ids_list.append(input_ids)
             prompt_attn_list.append(attention_mask)
             targets.append(target)
             sources.append(source)
-        model: Any = self.model
-        model.eval()
+        self.model.eval()
 
         # Left-pad for generation: reverse → pad_sequence → reverse
         batch_input_ids = (
@@ -448,7 +422,7 @@ class PreTrainer:
         )
         new_tokens = sequences[:, batch_input_ids.shape[1] :]
         decoded_strs = [
-            tokenizer.decode(
+            self.tokenizer.decode(
                 tokens.tolist(),
                 skip_special_tokens=True,
             )


### PR DESCRIPTION
Summary

PreTrainer is meant to be a generic decoder trainer, but _log_inference hardcoded the prompt layout [bos] + source + [sep] — which is really the StringReverse dataset's format (the prompt half of PromptCompletionTransform.__call__). The "generic" trainer secretly knew one dataset's token scheme, so any dataset with a different prompt structure would silently get the wrong prompt.

This moves prompt construction to its rightful owner — the transform — and hands it to the trainer by dependency injection. The trainer now knows nothing dataset-specific; it only keeps generic decoder concerns (pad_token_id for batching, eos_token_id for stopping, decode for display).

Changes

- datasets/string_reverse.py — add PromptCompletionTransform.build_prompt(sample) -> list[int] (the prompt-only token ids); __call__ now reuses it, so the format has a single source of truth. Signature takes the full sample dict to stay consistent with __call__ and to support future multi-field prompts (e.g. chat templates).
- shared/main.py — pulls the transform off the train loader (unwrapping the random_split Subset) and injects it as prompt_transform= into PreTrainer.
- trainers/pretrainer.py — inference builds prompts via the injected transform instead of assembling special tokens itself; _setup_inference validates the transform exposes build_prompt; removed a stale comment referencing a non-existent dataset.get_item_inference.
