### PR TITLE
support returning attention weights from transformer forward pass

### DIFF
--- a/tests/models/transformer_test.py
+++ b/tests/models/transformer_test.py
@@ -55,14 +55,14 @@ def test_attention():
 
     # Test causal attention (default when padding_mask is None)
     attn.eval()
-    output, context = attn(x, cos, sin)
+    output, context, _ = attn(x, cos, sin)
     assert output.shape == x.shape
 
     # Test with padding mask
     # padding_mask shape (B, 1, 1, S)
     padding_mask = torch.ones(2, 1, 1, 10, dtype=torch.bool)
     padding_mask[:, :, :, -2:] = False  # Mask last 2 tokens
-    output, context = attn(x, cos, sin, padding_mask=padding_mask)
+    output, context, _ = attn(x, cos, sin, padding_mask=padding_mask)
     assert output.shape == x.shape
 
     # Non-divisible embed_dim should raise an assertion error
@@ -97,23 +97,23 @@ def test_attention_context_and_dropout_behavior():
     cos, sin = rope(x, seq_len=10)
 
     # context shape should match (B, S, C)
-    output, context = attn(x, cos, sin)
+    output, context, _ = attn(x, cos, sin)
     assert context.shape == x.shape
 
     # Dropout should be disabled in eval mode (deterministic outputs across different seeds)
     attn.eval()
     torch.manual_seed(0)
-    out1, _ = attn(x, cos, sin)
+    out1, _, _ = attn(x, cos, sin)
     torch.manual_seed(1)
-    out2, _ = attn(x, cos, sin)
+    out2, _, _ = attn(x, cos, sin)
     assert torch.allclose(out1, out2)
 
     # In train mode with different seeds outputs are expected to differ due to dropout randomness
     attn.train()
     torch.manual_seed(0)
-    out3, _ = attn(x, cos, sin)
+    out3, _, _ = attn(x, cos, sin)
     torch.manual_seed(1)
-    out4, _ = attn(x, cos, sin)
+    out4, _, _ = attn(x, cos, sin)
     # It's extremely unlikely these are exactly equal when dropout is active
     assert not torch.allclose(out3, out4)
 

--- a/trainite/models/transformer.py
+++ b/trainite/models/transformer.py
@@ -2,9 +2,9 @@ import math
 from typing import Protocol
 
 import torch
+from pydantic import Field
 from torch import nn
 from torch.nn.utils.rnn import pad_sequence
-from pydantic import Field
 
 from trainite.config.base import ComponentConfig
 
@@ -110,36 +110,28 @@ class Attention(nn.Module):
         attn_weights = None
         if output_attentions:
             attn_scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.head_dim)
+            causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
+            mask = causal_mask
             if padding_mask is not None:
-                causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
                 mask = causal_mask & padding_mask
-                attn_scores = attn_scores.masked_fill(~mask, float("-inf"))
-            else:
-                causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
-                attn_scores = attn_scores.masked_fill(~causal_mask, float("-inf"))
+            attn_scores = attn_scores.masked_fill(~mask, float("-inf"))
             attn_weights = torch.softmax(attn_scores, dim=-1)
             context = torch.matmul(attn_weights, v)
         else:
-            # padding mask shape should be (B,1,1,S) to broadcast correctly with attention scores of shape (B, num_heads, S, S)
+            is_causal = True
+            mask = None
             if padding_mask is not None:
                 causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
                 mask = causal_mask & padding_mask
-                context = nn.functional.scaled_dot_product_attention(
-                    q,
-                    k,
-                    v,
-                    attn_mask=mask,
-                    is_causal=False,
-                    dropout_p=self.dropout_p if self.training else 0.0,
-                )
-            else:
-                context = nn.functional.scaled_dot_product_attention(
-                    q,
-                    k,
-                    v,
-                    is_causal=True,
-                    dropout_p=self.dropout_p if self.training else 0.0,
-                )
+                is_causal = False
+            context = nn.functional.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                is_causal=is_causal,
+                dropout_p=self.dropout_p if self.training else 0.0,
+            )
         context = context.transpose(1, 2).contiguous().view(B, S, C)
         out = self.out(context)
         return self.dropout(out), context, attn_weights

--- a/trainite/models/transformer.py
+++ b/trainite/models/transformer.py
@@ -92,7 +92,8 @@ class Attention(nn.Module):
         cos: torch.Tensor,
         sin: torch.Tensor,
         padding_mask: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        output_attentions: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         B, S, C = x.shape
 
         qkv = self.qkv_projection(x)
@@ -106,29 +107,42 @@ class Attention(nn.Module):
         # Apply Rotary Position Embeddings
         q, k = apply_rotary_pos_emb(q, k, cos, sin)
 
-        # padding mask shape should be (B,1,1,S) to broadcast correctly with attention scores of shape (B, num_heads, S, S)
-        if padding_mask is not None:
-            causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
-            mask = causal_mask & padding_mask
-            context = nn.functional.scaled_dot_product_attention(
-                q,
-                k,
-                v,
-                attn_mask=mask,
-                is_causal=False,
-                dropout_p=self.dropout_p if self.training else 0.0,
-            )
+        attn_weights = None
+        if output_attentions:
+            attn_scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.head_dim)
+            if padding_mask is not None:
+                causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
+                mask = causal_mask & padding_mask
+                attn_scores = attn_scores.masked_fill(~mask, float("-inf"))
+            else:
+                causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
+                attn_scores = attn_scores.masked_fill(~causal_mask, float("-inf"))
+            attn_weights = torch.softmax(attn_scores, dim=-1)
+            context = torch.matmul(attn_weights, v)
         else:
-            context = nn.functional.scaled_dot_product_attention(
-                q,
-                k,
-                v,
-                is_causal=True,
-                dropout_p=self.dropout_p if self.training else 0.0,
-            )
+            # padding mask shape should be (B,1,1,S) to broadcast correctly with attention scores of shape (B, num_heads, S, S)
+            if padding_mask is not None:
+                causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
+                mask = causal_mask & padding_mask
+                context = nn.functional.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    attn_mask=mask,
+                    is_causal=False,
+                    dropout_p=self.dropout_p if self.training else 0.0,
+                )
+            else:
+                context = nn.functional.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    is_causal=True,
+                    dropout_p=self.dropout_p if self.training else 0.0,
+                )
         context = context.transpose(1, 2).contiguous().view(B, S, C)
         out = self.out(context)
-        return self.dropout(out), context
+        return self.dropout(out), context, attn_weights
 
 
 class TransformerBlock(nn.Module):
@@ -151,13 +165,19 @@ class TransformerBlock(nn.Module):
         cos: torch.Tensor,
         sin: torch.Tensor,
         padding_mask: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        output_attentions: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         normed = self.norm1(x)
-        attn_output, _ = self.attention(normed, cos, sin, padding_mask=padding_mask)
+        attn_output, _, attn_weights = self.attention(
+            normed, cos, sin, padding_mask=padding_mask, output_attentions=output_attentions
+        )
         x = x + attn_output
 
         normed = self.norm2(x)
         x = x + self.feedforward(normed)
+        if output_attentions:
+            assert attn_weights is not None
+            return x, attn_weights
         return x
 
 
@@ -190,7 +210,9 @@ class TransformerModel(nn.Module):
         self.proj = nn.Linear(hidden_size, vocab_size)
         self.norm = nn.LayerNorm(hidden_size)
 
-    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, input_ids: torch.Tensor, output_attentions: bool = False
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
         B, S = input_ids.shape
         x = self.embedding(input_ids) * math.sqrt(self.embedding.embedding_dim)
         cos, sin = self.rotary_emb(x, seq_len=S)
@@ -198,10 +220,18 @@ class TransformerModel(nn.Module):
             padding_mask = (input_ids != self.embedding.padding_idx).reshape(B, 1, 1, S)
         else:
             padding_mask = None
+        all_attentions = []
         for block in self.blocks:
-            x = block(x, cos, sin, padding_mask=padding_mask)
+            if output_attentions:
+                x, attn_weights = block(x, cos, sin, padding_mask=padding_mask, output_attentions=True)
+                all_attentions.append(attn_weights)
+            else:
+                x = block(x, cos, sin, padding_mask=padding_mask, output_attentions=False)
         x = self.norm(x)
-        return self.proj(x)
+        logits = self.proj(x)
+        if output_attentions:
+            return logits, all_attentions
+        return logits
 
     @torch.no_grad()
     def generate(


### PR DESCRIPTION
## Description

### Context & Goals
Exposing attention weights from transformer models is crucial for interpretability, diagnostic audits, and verifying model alignment (e.g. visualizing the diagonal reverse-mapping learned in the string-reversal task). 

This PR adds the optional capability to return the self-attention weights from the forward pass of the model, blocks, and attention layers, while maintaining maximum performance optimizations during standard training.

### Key Changes
1. **Attention Layer Update (`trainite/models/transformer.py`)**:
   - Added an `output_attentions` boolean flag to the `Attention.forward` signature.
   - When `output_attentions=True`, it bypasses `nn.functional.scaled_dot_product_attention` (which does not expose internal weights) and manually calculates the attention weights matrix via Query-Key dot products and Softmax, applying both causal and padding masks.
   - Returns a 3-tuple: `(output, context, attention_weights)`.
2. **SDPA Unification & Refactoring**:
   - Cleaned up the `scaled_dot_product_attention` invocation code in `Attention.forward` by dynamically setting the `mask` and `is_causal` variables first. This avoids duplicate code lines and maintains hardware-optimized FlashAttention execution when `output_attentions` is `False`.
3. **Block & Model Layer Propagation**:
   - Propagated the `output_attentions` flag down from `TransformerModel` through `TransformerBlock` to `Attention`.
   - `TransformerModel` returns a list of attention weight tensors (one per layer/block) along with the final model logits when `output_attentions=True`.
4. **Test Suite Alignment (`tests/models/transformer_test.py`)**:
   - Updated the attention test assertions to unpack the newly introduced 3-value tuple returned by `Attention.forward`.

---