### PR TITLE
Refactor `ComponentConfig` to `BaseModel` & Add Collate Config

### DIFF
--- a/tests/config/base_test.py
+++ b/tests/config/base_test.py
@@ -1,19 +1,23 @@
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from trainite.config.base import (
-    ComponentConfig,
     DataConfigBase,
     DataWithAutoSplit,
     SplitConfig,
 )
 
 
+class MockComponent(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    target: str = Field(alias="_target_")
+
+
 def test_data_config_option_1():
     # Valid Option 1
     config = DataConfigBase(
-        train=SplitConfig(dataset=ComponentConfig(_target_="dataset.train")),
-        val=SplitConfig(dataset=ComponentConfig(_target_="dataset.val")),
+        train=SplitConfig(dataset=MockComponent(_target_="dataset.train")),
+        val=SplitConfig(dataset=MockComponent(_target_="dataset.val")),
     )
     assert config.train is not None
     assert config.val is not None
@@ -26,13 +30,13 @@ def test_data_config_option_1_missing_train():
         ValidationError,
         match="Field required",
     ):
-        DataConfigBase(val=SplitConfig(dataset=ComponentConfig(_target_="dataset.val")))
+        DataConfigBase(val=SplitConfig(dataset=MockComponent(_target_="dataset.val")))  # type: ignore
 
 
 def test_data_config_option_2():
     # Valid Option 2
     config = DataWithAutoSplit(
-        dataset=ComponentConfig(_target_="dataset.all"),
+        dataset=MockComponent(_target_="dataset.all"),
         test_ratio=0.2,
         val_ratio=0.1,
     )
@@ -47,7 +51,7 @@ def test_data_config_option_2_missing_dataset():
         ValidationError,
         match="Field required",
     ):
-        DataWithAutoSplit(test_ratio=0.2, val_ratio=0.1)
+        DataWithAutoSplit(test_ratio=0.2, val_ratio=0.1)  # type: ignore
 
 
 def test_data_config_invalid_ratios():
@@ -56,7 +60,7 @@ def test_data_config_invalid_ratios():
         match="greater than or equal to 0",
     ):
         DataWithAutoSplit(
-            dataset=ComponentConfig(_target_="dataset.all"),
+            dataset=MockComponent(_target_="dataset.all"),
             test_ratio=-0.1,
         )
 
@@ -65,7 +69,7 @@ def test_data_config_invalid_ratios():
         match="less than 0.5",
     ):
         DataWithAutoSplit(
-            dataset=ComponentConfig(_target_="dataset.all"),
+            dataset=MockComponent(_target_="dataset.all"),
             test_ratio=0.5,
         )
 
@@ -74,7 +78,7 @@ def test_data_config_invalid_ratios():
         match="greater than 0",
     ):
         DataWithAutoSplit(
-            dataset=ComponentConfig(_target_="dataset.all"),
+            dataset=MockComponent(_target_="dataset.all"),
             val_ratio=0.0,
         )
 
@@ -83,7 +87,7 @@ def test_data_config_invalid_ratios():
         match="less than 0.3",
     ):
         DataWithAutoSplit(
-            dataset=ComponentConfig(_target_="dataset.all"),
+            dataset=MockComponent(_target_="dataset.all"),
             val_ratio=0.3,
         )
 
@@ -92,7 +96,7 @@ def test_data_config_invalid_ratios():
         match="must be greater than 0.5",
     ):
         DataWithAutoSplit(
-            dataset=ComponentConfig(_target_="dataset.all"),
+            dataset=MockComponent(_target_="dataset.all"),
             test_ratio=0.3,
             val_ratio=0.25,  # test_ratio + val_ratio = 0.55, train = 0.45 <= 0.5
         )
@@ -102,7 +106,7 @@ def test_data_config_invalid_ratios():
         match="must be less than or equal to 0.9",
     ):
         DataWithAutoSplit(
-            dataset=ComponentConfig(_target_="dataset.all"),
+            dataset=MockComponent(_target_="dataset.all"),
             test_ratio=0.01,
             val_ratio=0.01,  # test_ratio + val_ratio = 0.02, train = 0.98 > 0.9
         )
@@ -112,9 +116,9 @@ def test_data_config_empty():
     with pytest.raises(
         ValidationError,
     ):
-        DataConfigBase()
+        DataConfigBase()  # type: ignore
 
     with pytest.raises(
         ValidationError,
     ):
-        DataWithAutoSplit()
+        DataWithAutoSplit()  # type: ignore

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -7,9 +7,8 @@ from unittest import mock
 import pytest
 import torch
 import torch.nn as nn
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from trainite.config import (
-    ComponentConfig,
     DataConfigBase,
     DataLoaderConfig,
     DataWithAutoSplit,
@@ -48,11 +47,16 @@ def create_trainer_from_config(config: ProjectConfig) -> DecoderTrainer:
     )
 
 
-def cc(target: str | None = None, **kwargs: object) -> ComponentConfig:
-    """Helper to create ComponentConfig with extra arguments without type errors."""
+class MockComponent(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    target: str = Field(alias="_target_")
+
+
+def cc(target: str | None = None, **kwargs: object) -> MockComponent:
+    """Helper to create MockComponent with extra arguments without type errors."""
     if target:
         kwargs["_target_"] = target
-    return ComponentConfig.model_validate(kwargs)
+    return MockComponent.model_validate(kwargs)
 
 
 class SimpleModel(nn.Module):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -2,9 +2,12 @@ import pytest
 
 from pydantic import BaseModel, ConfigDict, Field
 
+
 class MockComponent(BaseModel):
     model_config = ConfigDict(extra="allow")
     target: str = Field(alias="_target_")
+
+
 from trainite.shared.utils import get_target, instantiate
 
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,14 +1,18 @@
 import pytest
 
-from trainite.config import ComponentConfig
+from pydantic import BaseModel, ConfigDict, Field
+
+class MockComponent(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    target: str = Field(alias="_target_")
 from trainite.shared.utils import get_target, instantiate
 
 
-def cc(target: str | None = None, **kwargs: object) -> ComponentConfig:
-    """Helper to create ComponentConfig with extra arguments without type errors."""
+def cc(target: str | None = None, **kwargs: object) -> MockComponent:
+    """Helper to create MockComponent with extra arguments without type errors."""
     if target:
         kwargs["_target_"] = target
-    return ComponentConfig.model_validate(kwargs)
+    return MockComponent.model_validate(kwargs)
 
 
 def test_get_target_success():

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -11,7 +11,6 @@ from packaging.requirements import Requirement
 from pydantic import BaseModel, ConfigDict, Field
 
 from trainite.config import (
-    ComponentConfig,
     DataConfigBase,
     DataWithAutoSplit,
     OptimizerConfig,
@@ -23,8 +22,8 @@ from trainite.shared.utils import dump_config
 
 class ProjectConfig(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
-    preprocessor: ComponentConfig | None = None
-    model: ComponentConfig
+    preprocessor: BaseModel | None = None
+    model: BaseModel
     optimizer: OptimizerConfig = Field(default_factory=OptimizerConfig)
     data: DataConfigBase | DataWithAutoSplit
     trainer: BaseModel
@@ -210,7 +209,7 @@ def _build_templates(model_name: str, dataset_name: str, trainer_name: str, proj
     # Dynamic replacements that depend on the user's model/dataset/trainer selection.
     trainer_replacements = [
         *trainer_spec.template_replacements,
-        ("model: ComponentConfig", f"model: {model_spec.config_cls.__name__}"),
+        ("model: BaseModel", f"model: {model_spec.config_cls.__name__}"),
         (
             "data: DataConfigBase | DataWithAutoSplit",
             f"data: {dataset_spec.config_cls.__name__}",
@@ -228,7 +227,7 @@ def _build_templates(model_name: str, dataset_name: str, trainer_name: str, proj
     if preprocessor_spec:
         trainer_replacements.extend(
             [
-                ("preprocessor: ComponentConfig", f"preprocessor: {preprocessor_spec.config_cls.__name__}"),
+                ("preprocessor: BaseModel", f"preprocessor: {preprocessor_spec.config_cls.__name__}"),
                 (
                     "# __PREPROCESSOR_IMPORT__",
                     f"from preprocessors.{preprocessor_spec.name} import {preprocessor_spec.config_cls.__name__}",
@@ -293,13 +292,25 @@ def _build_templates(model_name: str, dataset_name: str, trainer_name: str, proj
             preprocessor_spec.template_replacements,
         )
 
+    config_replacements = []
+    if model_spec.collate_fn_config_cls:
+        collate_config_cls = model_spec.collate_fn_config_cls
+        config_replacements.extend([
+            ("collate_fn: BaseModel | None = None", f"collate_fn: {collate_config_cls.__name__} | None = None"),
+            ("# __COLLATE_IMPORT__", f"from models.{model_spec.name} import {collate_config_cls.__name__}"),
+        ])
+    else:
+        config_replacements.extend([
+            ("# __COLLATE_IMPORT__", ""),
+        ])
+
     templates.update(
         {
             "trainer.py": _render_template(PROJECT_ROOT / trainer_spec.implementation_path, trainer_replacements),
             "utils.py": _render_template(PROJECT_ROOT / "trainite/shared/utils.py"),
             "main.py": _render_template(PROJECT_ROOT / "trainite/shared/main.py", main_replacements),
             "README.md": _render_template(PROJECT_ROOT / "trainite/templates/project/README.md", readme_replacements),
-            "config.py": _render_template(PROJECT_ROOT / "trainite/config/base.py"),
+            "config.py": _render_template(PROJECT_ROOT / "trainite/config/base.py", config_replacements),
             "pyproject.toml": generate_uv_project(name=project_name, version="0.1.0", dependencies=sorted(final_deps)),
         }
     )
@@ -347,8 +358,10 @@ def run_interactive_mode() -> None:
 
 
 def _update_targets(config: Any, old_prefix: str, new_prefix: str) -> None:
-    if isinstance(config, ComponentConfig) and config.target.startswith(old_prefix):
-        config.target = config.target.replace(old_prefix, new_prefix, 1)
+    if isinstance(config, BaseModel) and hasattr(config, "target"):
+        target = getattr(config, "target")
+        if isinstance(target, str) and target.startswith(old_prefix):
+            setattr(config, "target", target.replace(old_prefix, new_prefix, 1))
     elif isinstance(config, BaseModel):
         for field in config.model_fields:
             if (val := getattr(config, field)) is not None:
@@ -419,12 +432,25 @@ def init_project(config: Init) -> None:
 
     # Inject model collator into data config dataloaders
     if model_spec.collate_fn_target:
-        collate_target = model_spec.collate_fn_target
+        class GenericComponent(BaseModel):
+            model_config = ConfigDict(extra="allow")
+            target: str = Field(alias="_target_")
+
+        if model_spec.collate_fn_config_cls:
+            collate_config_cls = model_spec.collate_fn_config_cls
+            collate_fn_instance = collate_config_cls()
+            collate_fn_val = GenericComponent(
+                _target_=collate_fn_instance.target,
+                **collate_fn_instance.model_dump(by_alias=True, exclude={"target"}),
+            )
+        else:
+            collate_target = model_spec.collate_fn_target
+            collate_fn_val = GenericComponent(_target_=collate_target)
 
         def _inject_collate(config: Any):
             dataloader = getattr(config, "dataloader", None)
             if dataloader is not None:
-                dataloader.collate_fn = ComponentConfig(_target_=collate_target)
+                dataloader.collate_fn = collate_fn_val
             for split in ["train", "val", "test"]:
                 split_config = getattr(config, split, None)
                 if split_config is not None:

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -295,14 +295,18 @@ def _build_templates(model_name: str, dataset_name: str, trainer_name: str, proj
     config_replacements = []
     if model_spec.collate_fn_config_cls:
         collate_config_cls = model_spec.collate_fn_config_cls
-        config_replacements.extend([
-            ("collate_fn: BaseModel | None = None", f"collate_fn: {collate_config_cls.__name__} | None = None"),
-            ("# __COLLATE_IMPORT__", f"from models.{model_spec.name} import {collate_config_cls.__name__}"),
-        ])
+        config_replacements.extend(
+            [
+                ("collate_fn: BaseModel | None = None", f"collate_fn: {collate_config_cls.__name__} | None = None"),
+                ("# __COLLATE_IMPORT__", f"from models.{model_spec.name} import {collate_config_cls.__name__}"),
+            ]
+        )
     else:
-        config_replacements.extend([
-            ("# __COLLATE_IMPORT__", ""),
-        ])
+        config_replacements.extend(
+            [
+                ("# __COLLATE_IMPORT__", ""),
+            ]
+        )
 
     templates.update(
         {
@@ -432,6 +436,7 @@ def init_project(config: Init) -> None:
 
     # Inject model collator into data config dataloaders
     if model_spec.collate_fn_target:
+
         class GenericComponent(BaseModel):
             model_config = ConfigDict(extra="allow")
             target: str = Field(alias="_target_")

--- a/trainite/config/__init__.py
+++ b/trainite/config/__init__.py
@@ -1,5 +1,4 @@
 from trainite.config.base import (
-    ComponentConfig,
     DataConfigBase,
     DataLoaderConfig,
     DataWithAutoSplit,
@@ -9,7 +8,6 @@ from trainite.config.base import (
 )
 
 __all__ = [
-    "ComponentConfig",
     "DataConfigBase",
     "DataWithAutoSplit",
     "DataLoaderConfig",

--- a/trainite/config/base.py
+++ b/trainite/config/base.py
@@ -1,3 +1,4 @@
+# __COLLATE_IMPORT__
 from typing import Self
 
 from pydantic import (
@@ -14,11 +15,6 @@ class OutputConfig(BaseModel):
     run_name: str
 
 
-class ComponentConfig(BaseModel):
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
-    target: str = Field(alias="_target_")
-
-
 class OptimizerConfig(BaseModel):
     model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: str = Field(alias="_target_", default="torch.optim.AdamW")
@@ -30,13 +26,13 @@ class DataLoaderConfig(BaseModel):
     batch_size: int = Field(default=32, gt=0)
     shuffle: bool = False
     num_workers: int = Field(default=2, ge=0)
-    collate_fn: ComponentConfig | None = None
+    collate_fn: BaseModel | None = None
 
 
 class SplitConfig(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
-    dataset: ComponentConfig
-    transform: ComponentConfig | None = None
+    dataset: BaseModel
+    transform: BaseModel | None = None
     dataloader: DataLoaderConfig = Field(default_factory=DataLoaderConfig)
 
 
@@ -50,8 +46,8 @@ class DataConfigBase(BaseModel):
 class DataWithAutoSplit(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
     # Option 2: Automatic splitting
-    dataset: ComponentConfig
-    transform: ComponentConfig | None = None
+    dataset: BaseModel
+    transform: BaseModel | None = None
     dataloader: DataLoaderConfig = Field(default_factory=DataLoaderConfig)
     test_ratio: float = Field(default=0.2, ge=0.0, lt=0.5)
     val_ratio: float = Field(default=0.1, gt=0.0, lt=0.3)

--- a/trainite/config/registry.py
+++ b/trainite/config/registry.py
@@ -29,6 +29,11 @@ class TrainerSpec(ComponentSpec):
 class ModelSpec(ComponentSpec):
     builder_symbol: str
     collate_fn_target: str | None = None
+    collate_fn_config_cls_path: str | None = None
+
+    @property
+    def collate_fn_config_cls(self) -> type[BaseModel] | None:
+        return get_target(self.collate_fn_config_cls_path) if self.collate_fn_config_cls_path else None
 
 
 class DatasetSpec(ComponentSpec):
@@ -53,6 +58,7 @@ MODEL_SPECS = {
         implementation_symbol="TransformerModel",
         builder_symbol="TransformerModel",
         collate_fn_target="trainite.models.transformer.CausalLMCollateFn",
+        collate_fn_config_cls_path="trainite.models.transformer.CausalLMCollateFnConfig",
         template_replacements=[
             ("trainite.shared.utils", "utils"),
             ("trainite.models", "models"),

--- a/trainite/datasets/string_reverse.py
+++ b/trainite/datasets/string_reverse.py
@@ -4,10 +4,10 @@ import warnings
 from typing import Any
 
 import torch
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from torch.utils.data import Dataset
 
-from trainite.config.base import ComponentConfig, DataLoaderConfig, DataWithAutoSplit
+from trainite.config.base import DataLoaderConfig, DataWithAutoSplit
 
 # Hardcoded universal vocabulary: all printable ASCII characters
 UNIVERSAL_VOCAB = string.ascii_letters + string.digits + string.punctuation + " "
@@ -135,7 +135,7 @@ class PromptCompletionTransform:
         source_tokens = self.tokenizer(sample["source"], add_special_tokens=False)["input_ids"]
         return [bos] + source_tokens + [sep]
 
-    def __call__(self, sample: dict[str, str]) -> dict[str, torch.Tensor]:
+    def __call__(self, sample: dict[str, str]) -> dict[str, torch.Tensor | str]:
         source = sample["source"]
         target = sample["target"]
 
@@ -164,8 +164,8 @@ class PromptCompletionTransform:
         }
 
 
-class PromptCompletionTransformConfig(ComponentConfig):
-    model_config = ConfigDict(validate_assignment=True)
+class PromptCompletionTransformConfig(BaseModel):
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: str = Field(
         default="trainite.datasets.string_reverse.PromptCompletionTransform",
         alias="_target_",
@@ -173,8 +173,8 @@ class PromptCompletionTransformConfig(ComponentConfig):
     ignore_index: int = -100
 
 
-class StringReverseDatasetConfig(ComponentConfig):
-    model_config = ConfigDict(validate_assignment=True)
+class StringReverseDatasetConfig(BaseModel):
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: str = Field(
         default="trainite.datasets.string_reverse.StringReverseDataset",
         alias="_target_",

--- a/trainite/models/transformer.py
+++ b/trainite/models/transformer.py
@@ -2,11 +2,9 @@ import math
 from typing import Any
 
 import torch
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field
 from torch import nn
 from torch.nn.utils.rnn import pad_sequence
-
-from trainite.config.base import ComponentConfig
 
 
 class RotaryEmbedding(nn.Module):
@@ -235,7 +233,8 @@ class CausalLMCollateFn:
         }
 
 
-class TransformerModelConfig(ComponentConfig):
+class TransformerModelConfig(BaseModel):
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: str = Field(default="trainite.models.transformer.TransformerModel", alias="_target_")
     hidden_size: int = Field(default=64, gt=0)
     num_layers: int = Field(default=2, gt=0)
@@ -243,3 +242,13 @@ class TransformerModelConfig(ComponentConfig):
     feedforward_dim: int = Field(default=128, gt=0)
     dropout: float = Field(default=0.1, ge=0.0, lt=1.0)
     max_seq_len: int = Field(default=128, gt=0)
+
+
+class CausalLMCollateFnConfig(BaseModel):
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+    target: str = Field(
+        default="trainite.models.transformer.CausalLMCollateFn",
+        alias="_target_",
+    )
+    ignore_index: int = Field(default=-100)
+    pad_token_id: int | None = Field(default=None)

--- a/trainite/preprocessors/char_tokenizer.py
+++ b/trainite/preprocessors/char_tokenizer.py
@@ -2,8 +2,7 @@ import string
 from typing import Any
 
 import torch
-from pydantic import Field
-from trainite.config.base import ComponentConfig
+from pydantic import BaseModel, ConfigDict, Field
 
 # Hardcoded universal vocabulary: all printable ASCII characters
 UNIVERSAL_VOCAB = string.ascii_letters + string.digits + string.punctuation + " "
@@ -150,7 +149,8 @@ class CharTokenizer:
         return out
 
 
-class CharTokenizerConfig(ComponentConfig):
+class CharTokenizerConfig(BaseModel):
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: str = Field(
         default="trainite.preprocessors.char_tokenizer.CharTokenizer",
         alias="_target_",

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -22,7 +22,6 @@ from torch.optim.lr_scheduler import LinearLR
 from torch.utils.data import DataLoader, Subset
 
 from trainite.config.base import (
-    ComponentConfig,
     DataConfigBase,
     DataWithAutoSplit,
     OptimizerConfig,
@@ -49,8 +48,8 @@ class DecoderTrainerConfig(BaseModel):
 
 class ProjectConfig(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
-    preprocessor: ComponentConfig | None = None
-    model: ComponentConfig
+    preprocessor: BaseModel | None = None
+    model: BaseModel
     optimizer: OptimizerConfig = Field(default_factory=OptimizerConfig)
     data: DataConfigBase | DataWithAutoSplit
     trainer: DecoderTrainerConfig = Field(default_factory=DecoderTrainerConfig)


### PR DESCRIPTION
## Description

### Summary
This PR refactors the configuration system in Trainite to use Pydantic's `BaseModel` directly for component configurations, removing the generic `ComponentConfig` class. 

During project initialization (`trainite init`), the CLI dynamically replaces the generic `BaseModel` type hints in `ProjectConfig` and `DataLoaderConfig` with the specific configuration classes selected by the user (e.g., `model: TransformerModelConfig`, `collate_fn: CausalLMCollateFnConfig`). This provides specific type-safety, strict validation, and full IDE autocompletion in the generated project.

Part of #74 