### PR TITLE
Simplify device specification using native idist.device()

### DIFF
--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -17,10 +17,10 @@ from trainite.config import (
     OutputConfig,
     SplitConfig,
 )
+import ignite.distributed as idist
 from trainite.shared.main import (
     build_dataloaders,
     build_model,
-    resolve_device,
     resolve_vocab_size,
 )
 from trainite.shared.utils import instantiate
@@ -30,7 +30,7 @@ from ignite.handlers import EarlyStopping
 
 
 def create_trainer_from_config(config: ProjectConfig) -> DecoderTrainer:
-    device = resolve_device(config.device)
+    device = idist.device() if config.device is None else config.device
     tokenizer = instantiate(config.preprocessor)  # type: ignore
     train_loader, val_loader, test_loader = build_dataloaders(config.data, tokenizer, config.seed)
     vocab_size = resolve_vocab_size(tokenizer, config.model)
@@ -251,7 +251,7 @@ def project_config(temp_run_dir):
             max_inference_new_tokens=10,
         ),
         output=OutputConfig(root=str(temp_run_dir), run_name="test_run"),
-        device="auto",
+        device=None,
     )
 
 

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -30,7 +30,7 @@ class ProjectConfig(BaseModel):
     trainer: BaseModel
     output: OutputConfig
     seed: int = 42
-    device: str = "auto"
+    device: str | None = None
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]

--- a/trainite/shared/main.py
+++ b/trainite/shared/main.py
@@ -3,6 +3,7 @@ import inspect
 from pathlib import Path
 from typing import Any
 
+import ignite.distributed as idist
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, Dataset, Subset, random_split
@@ -16,13 +17,6 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("config", nargs="?", default="config.yaml")
     return parser.parse_args()
-
-
-def resolve_device(device: str) -> str | torch.device:
-    resolved = device
-    if resolved == "auto":
-        resolved = "cuda" if torch.cuda.is_available() else "cpu"
-    return resolved
 
 
 def resolve_vocab_size(tokenizer: Any, model_config: Any) -> int:
@@ -162,7 +156,7 @@ def main() -> None:
     config_path = Path(args.config)
     config = load_config(config_path, ProjectConfig)
 
-    device = resolve_device(config.device)
+    device = idist.device() if config.device is None else config.device
     tokenizer = instantiate(config.preprocessor) if config.preprocessor is not None else None
 
     train_loader, val_loader, test_loader = build_dataloaders(config.data, tokenizer, config.seed)

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
+import ignite.distributed as idist
 from ignite.engine import Engine, Events
 from ignite.handlers import (
     Checkpoint,
@@ -56,7 +57,7 @@ class ProjectConfig(BaseModel):
     trainer: DecoderTrainerConfig = Field(default_factory=DecoderTrainerConfig)
     output: OutputConfig
     seed: int = 42
-    device: str = "auto"
+    device: str | None = None
 
 
 class DecoderTrainer:
@@ -76,7 +77,7 @@ class DecoderTrainer:
         self.config: ProjectConfig = config
         self.tokenizer = preprocessor
         self.prompt_transform = prompt_transform
-        self.device: str | torch.device = self._resolve_device()
+        self.device: str | torch.device = idist.device() if config.device is None else config.device
         self.epochs: int = config.trainer.epochs
         self.grad_clip_norm: float | None = getattr(config.trainer, "grad_clip_norm", None)
         self.train_loader = train_loader
@@ -123,12 +124,6 @@ class DecoderTrainer:
         if self.inference_every_epochs is not None:
             self._setup_inference()
             self.attach_inference_logger()
-
-    def _resolve_device(self) -> str | torch.device:
-        resolved = self.config.device
-        if resolved == "auto":
-            resolved = "cuda" if torch.cuda.is_available() else "cpu"
-        return resolved
 
     def _make_run_dir(self) -> Path:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")


### PR DESCRIPTION
## Description

This PR replaces the custom device resolution logic with PyTorch-Ignite's native `ignite.distributed` (`idist`) module. This simplifies the codebase, removes duplicate resolution functions, and automatically aligns the scaffolding setup for multi-GPU / Distributed Data Parallel (DDP) scale.

Part of #74 