### PR TITLE
make trainer-name generic

### DIFF
--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -16,14 +16,14 @@ from trainite.config import (
     OutputConfig,
     SplitConfig,
 )
-from trainite.trainers.decoder_trainer import DecoderTrainer, DecoderTrainerConfig, ProjectConfig
+from trainite.trainers.decoder_trainer import Trainer, TrainerConfig, ProjectConfig
 from ignite.engine import Events
 from ignite.handlers import EarlyStopping
 import ignite.distributed as idist
 
 
-def create_trainer_from_config(config: ProjectConfig) -> DecoderTrainer:
-    return DecoderTrainer(config)
+def create_trainer_from_config(config: ProjectConfig) -> Trainer:
+    return Trainer(config)
 
 
 class MockComponent(BaseModel):
@@ -224,7 +224,7 @@ def project_config(temp_run_dir):
                 dataloader=DataLoaderConfig(batch_size=4),
             ),
         ),
-        trainer=DecoderTrainerConfig(
+        trainer=TrainerConfig(
             epochs=1,
             log_every_steps=1,
             inference_every_epochs=None,
@@ -241,7 +241,7 @@ def test_flatten():
     logits = torch.randn(2, 3, 5)  # B=2, S=3, V=5
     targets = torch.tensor([[1, 2, -100], [0, -100, 3]])
 
-    trainer = DecoderTrainer.__new__(DecoderTrainer)
+    trainer = Trainer.__new__(Trainer)
     trainer.loss_fn = nn.CrossEntropyLoss(ignore_index=-100)
 
     output = {"logits": logits, "targets": targets}
@@ -475,7 +475,7 @@ def test_decoder_trainer_builds_train_and_val_loaders_from_ratios(tmp_path):
             test_ratio=0.0,
             val_ratio=0.2,
         ),
-        trainer=DecoderTrainerConfig(epochs=1),
+        trainer=TrainerConfig(epochs=1),
         output=OutputConfig(root=str(tmp_path), run_name="test"),
     )
 
@@ -508,7 +508,7 @@ def test_decoder_trainer_builds_train_val_and_test_loaders_from_ratios(tmp_path)
             test_ratio=0.2,
             val_ratio=0.2,
         ),
-        trainer=DecoderTrainerConfig(epochs=1),
+        trainer=TrainerConfig(epochs=1),
         output=OutputConfig(root=str(tmp_path), run_name="test"),
     )
 
@@ -585,7 +585,7 @@ def test_decoder_trainer_dataloader_class_collate_fn(project_config):
     assert isinstance(trainer.train_loader.collate_fn.tokenizer, DummyTokenizer)
 
 
-# Inference param validation now lives on DecoderTrainerConfig (Field(gt=0)), so bad
+# Inference param validation now lives on TrainerConfig (Field(gt=0)), so bad
 # values (non-positive or non-int) are rejected at config construction.
 @pytest.mark.parametrize(
     "kwargs",
@@ -602,7 +602,7 @@ def test_decoder_trainer_dataloader_class_collate_fn(project_config):
 )
 def test_invalid_inference_params_rejected(kwargs):
     with pytest.raises(ValidationError):
-        DecoderTrainerConfig(**kwargs)
+        TrainerConfig(**kwargs)
 
 
 def test_setup_inference_invalid_dataset_items(project_config):

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -246,11 +246,14 @@ def _build_templates(model_name: str, dataset_name: str, trainer_name: str, proj
 
     main_replacements = [
         (
-            "from trainite.trainers.decoder_trainer import DecoderTrainer, ProjectConfig",
-            f"from trainer import {trainer_spec.implementation_symbol}, ProjectConfig",
+            "from trainite.trainers.decoder_trainer",
+            "from trainer",
         ),
         ("trainite.shared.utils", "utils"),
-        ("DecoderTrainer(", f"{trainer_spec.implementation_symbol}("),
+        (
+            "from trainite.datasets.transformed import TransformedDataset",
+            "from datasets.transformed import TransformedDataset",
+        ),
     ]
 
     preprocessor_name = preprocessor_spec.name if preprocessor_spec else "None"

--- a/trainite/config/registry.py
+++ b/trainite/config/registry.py
@@ -90,8 +90,8 @@ TRAINER_SPECS = {
     "decoder-trainer": TrainerSpec(
         name="decoder_trainer",
         implementation_path=Path("trainite/trainers/decoder_trainer.py"),
-        config_cls_path="trainite.trainers.decoder_trainer.DecoderTrainerConfig",
-        implementation_symbol="DecoderTrainer",
+        config_cls_path="trainite.trainers.decoder_trainer.TrainerConfig",
+        implementation_symbol="Trainer",
         template_replacements=[
             ("trainite.shared.utils", "utils"),
             ("trainite.config.base", "config"),

--- a/trainite/shared/main.py
+++ b/trainite/shared/main.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 
 from trainite.shared.utils import load_config
-from trainite.trainers.decoder_trainer import DecoderTrainer, ProjectConfig
+from trainite.trainers.decoder_trainer import Trainer, ProjectConfig
 
 
 def main() -> None:
@@ -10,7 +10,7 @@ def main() -> None:
     parser.add_argument("config", nargs="?", default="config.yaml")
     args = parser.parse_args()
     config = load_config(Path(args.config), ProjectConfig)
-    trainer = DecoderTrainer(config)
+    trainer = Trainer(config)
     trainer.run()
 
 

--- a/trainite/trainers/__init__.py
+++ b/trainite/trainers/__init__.py
@@ -1,3 +1,3 @@
-from trainite.trainers.decoder_trainer import DecoderTrainer
+from trainite.trainers.decoder_trainer import Trainer
 
-__all__ = ["DecoderTrainer"]
+__all__ = ["Trainer"]

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -37,7 +37,7 @@ from trainite.datasets.transformed import TransformedDataset
 from trainite.shared.utils import dump_config, get_target, instantiate
 
 
-class DecoderTrainerConfig(BaseModel):
+class TrainerConfig(BaseModel):
     model_config = ConfigDict(extra="allow", validate_assignment=True)
     epochs: int = Field(default=3, gt=0)
     log_every_steps: int = Field(default=10, gt=0)
@@ -55,7 +55,7 @@ class ProjectConfig(BaseModel):
     model: BaseModel
     optimizer: OptimizerConfig = Field(default_factory=OptimizerConfig)
     data: DataConfigBase | DataWithAutoSplit
-    trainer: DecoderTrainerConfig = Field(default_factory=DecoderTrainerConfig)
+    trainer: TrainerConfig = Field(default_factory=TrainerConfig)
     output: OutputConfig
     seed: int = 42
     device: str | None = None
@@ -176,7 +176,7 @@ def build_dataloaders(data_config: Any, tokenizer: Any, seed: int) -> tuple[Data
     return _loaders_from_splits(data_config, tokenizer)
 
 
-class DecoderTrainer:
+class Trainer:
     def __init__(self, config: ProjectConfig) -> None:
         self.logger: logging.Logger = setup_logger("trainer", level=logging.INFO)
         torch.manual_seed(config.seed)


### PR DESCRIPTION
This pull request standardizes the naming of the main trainer class and its configuration throughout the codebase, replacing all references to `DecoderTrainer` and `DecoderTrainerConfig` with `Trainer` and `TrainerConfig`. This change improves consistency and generalizes the trainer interface, making it easier to extend or reuse the trainer for other tasks. The updates affect the core implementation, configuration registry, CLI template generation, shared entrypoints, and all related tests.

Key changes:

**Core implementation and configuration:**
* Renamed `DecoderTrainer` class to `Trainer` and `DecoderTrainerConfig` to `TrainerConfig` in `trainite/trainers/decoder_trainer.py`, including updates to all references and type annotations. [[1]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL40-R40) [[2]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL179-R179) [[3]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL58-R58)

**Public API and imports:**
* Updated the public API in `trainite/trainers/__init__.py` to export `Trainer` instead of `DecoderTrainer`.
* Changed all imports and usages of `DecoderTrainer`/`DecoderTrainerConfig` to `Trainer`/`TrainerConfig` in `trainite/shared/main.py` and throughout the test suite. [[1]](diffhunk://#diff-c2b9eceff9cbffbc58e5250d8cb6ecc53af0eb032186871fba184930a5625ab5L5-R13) [[2]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L19-R26) [[3]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L227-R227) [[4]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L244-R244) [[5]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L478-R478) [[6]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L511-R511) [[7]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L588-R588) [[8]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L605-R605)

**Configuration and registry:**
* Updated the trainer specification in the config registry to use the new class and config names (`Trainer`, `TrainerConfig`).

**CLI and template generation:**
* Adjusted the CLI template generation logic to use the new trainer symbol and import paths, ensuring generated projects reference `Trainer` instead of `DecoderTrainer`.