### PR TITLE
add transform contract

### DIFF
--- a/tests/datasets/string_reverse_test.py
+++ b/tests/datasets/string_reverse_test.py
@@ -177,25 +177,25 @@ def test_prompt_completion_transform():
     sample = {"source": "abc", "target": "cba"}
     item = transform(sample)
 
-    assert "input_ids" in item
-    assert "labels" in item
-    assert "attention_mask" in item
+    # Contract: DatapointModel carries source/target strings + train tensors + eval prompt
+    assert item.source == "abc"
+    assert item.target == "cba"
 
     # Check tensor shapes and types
-    assert item["input_ids"].dtype == torch.long
-    assert item["labels"].dtype == torch.long
-    assert item["attention_mask"].dtype == torch.long
+    assert item.train_input_ids.dtype == torch.long
+    assert item.train_label_ids.dtype == torch.long
+    assert item.attention_mask.dtype == torch.long
 
     # Auto-regressive shift: input_ids and labels should match, shifted by 1
-    assert len(item["input_ids"]) == len(item["labels"])
+    assert len(item.train_input_ids) == len(item.train_label_ids)
 
     # First token of input is BOS
-    assert item["input_ids"][0].item() == tokenizer.bos_token_id
+    assert item.train_input_ids[0].item() == tokenizer.bos_token_id
     # Last token of labels is EOS
-    assert item["labels"][-1].item() == tokenizer.eos_token_id
+    assert item.train_label_ids[-1].item() == tokenizer.eos_token_id
 
     # The SEP token must exist in the labels/inputs
-    sep_idx = (item["input_ids"] == tokenizer.sep_token_id).nonzero(as_tuple=True)[0][0].item()
+    sep_idx = (item.train_input_ids == tokenizer.sep_token_id).nonzero(as_tuple=True)[0][0].item()
     assert sep_idx > 0
 
     # Ensure label masking for the prompt part (BOS + source + SEP = 1 + 3 + 1 = 5 tokens)
@@ -203,9 +203,12 @@ def test_prompt_completion_transform():
     # labels corresponds to combined_input_ids[1:], so the first len(source_tokens) + 1 tokens are masked.
     source_tokens = tokenizer("abc", add_special_tokens=False)["input_ids"]
     masked_len = len(source_tokens) + 1
-    assert (item["labels"][:masked_len] == -100).all()
+    assert (item.train_label_ids[:masked_len] == -100).all()
     # The target tokens + EOS should NOT be masked
-    assert (item["labels"][masked_len:] != -100).all()
+    assert (item.train_label_ids[masked_len:] != -100).all()
 
     # All attention mask values should be 1
-    assert item["attention_mask"].eq(1).all()
+    assert item.attention_mask.eq(1).all()
+
+    # Eval prompt is [bos] + source + [sep], no target
+    assert item.eval_input_ids.tolist() == [tokenizer.bos_token_id] + source_tokens + [tokenizer.sep_token_id]

--- a/tests/models/transformer_test.py
+++ b/tests/models/transformer_test.py
@@ -8,6 +8,7 @@ from trainite.models.transformer import (
     TransformerBlock,
     TransformerModel,
 )
+from trainite.datasets.string_reverse import DatapointModel
 from trainite.preprocessors.char_tokenizer import CharTokenizer
 from trainite.shared.utils import instantiate
 
@@ -154,17 +155,22 @@ def test_causal_lm_collate_fn():
     src2 = "d"
     tgt2 = "d"
 
-    def make_item(source: str, target: str) -> dict:
+    def make_item(source: str, target: str) -> DatapointModel:
         source_ids = tokenizer.encode(source)
         target_ids = tokenizer.encode(target)
         combined = (
             [tokenizer.bos_token_id] + source_ids + [tokenizer.sep_token_id] + target_ids + [tokenizer.eos_token_id]
         )
-        return {
-            "input_ids": torch.tensor(combined[:-1], dtype=torch.long),
-            "labels": torch.tensor(combined[1:], dtype=torch.long),
-            "attention_mask": torch.ones(len(combined) - 1, dtype=torch.long),
-        }
+        return DatapointModel(
+            source=source,
+            target=target,
+            train_input_ids=torch.tensor(combined[:-1], dtype=torch.long),
+            train_label_ids=torch.tensor(combined[1:], dtype=torch.long),
+            attention_mask=torch.ones(len(combined) - 1, dtype=torch.long),
+            eval_input_ids=torch.tensor(
+                [tokenizer.bos_token_id] + source_ids + [tokenizer.sep_token_id], dtype=torch.long
+            ),
+        )
 
     batch = [make_item(src1, tgt1), make_item(src2, tgt2)]
 

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -16,6 +16,7 @@ from trainite.config import (
     OutputConfig,
     SplitConfig,
 )
+from trainite.datasets.string_reverse import DatapointModel
 from trainite.trainers.decoder_trainer import Trainer, TrainerConfig, ProjectConfig
 from ignite.engine import Events
 from ignite.handlers import EarlyStopping
@@ -102,17 +103,6 @@ class DummyClassCollateFn:
         return batch
 
 
-class SimpleDatasetWithTokenizer(SimpleDataset):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.tokenizer = "mock_tokenizer"
-
-
-class NonDictDataset(SimpleDatasetWithTokenizer):
-    def __getitem__(self, index):  # type: ignore[override]
-        return [1, 2, 3]
-
-
 class DummyTokenizer:
     def __init__(self):
         self.pad_token_id = 0
@@ -152,16 +142,24 @@ class GenerativeModel(SimpleModel):
 
 
 class DummyTransform:
-    """Passthrough transform that also supplies a prompt format for inference."""
+    """Transform emitting the DatapointModel contract (train tensors + eval prompt)."""
 
     def __init__(self, tokenizer: Any = None):
         self.tokenizer = tokenizer
 
     def __call__(self, sample):
-        return sample
-
-    def build_prompt(self, sample):
-        return [self.tokenizer.bos_token_id] + self.tokenizer.encode(sample["source"]) + [self.tokenizer.sep_token_id]
+        input_ids = sample["input_ids"]
+        prompt_ids = (
+            [self.tokenizer.bos_token_id] + self.tokenizer.encode(sample["source"]) + [self.tokenizer.sep_token_id]
+        )
+        return DatapointModel(
+            source=sample["source"],
+            target=sample["target"],
+            train_input_ids=input_ids,
+            train_label_ids=sample["labels"],
+            attention_mask=torch.ones(len(input_ids), dtype=torch.long),
+            eval_input_ids=torch.tensor(prompt_ids, dtype=torch.long),
+        )
 
 
 class GenerativeDataset(SimpleDataset):
@@ -605,46 +603,6 @@ def test_invalid_inference_params_rejected(kwargs):
         TrainerConfig(**kwargs)
 
 
-def test_setup_inference_invalid_dataset_items(project_config):
-    project_config.trainer.inference_every_epochs = 1
-    project_config.model = cc(
-        "tests.trainers.decoder_trainer_test.GenerativeModel",
-        vocab_size=10,
-        hidden_size=8,
-    )
-    project_config.data.train.dataset = cc(
-        "tests.trainers.decoder_trainer_test.SimpleDatasetWithTokenizer",
-        size=16,
-        seq_len=4,
-        vocab_size=10,
-    )
-    with pytest.raises(
-        ValueError,
-        match="must contain 'source' and 'target' keys",
-    ):
-        create_trainer_from_config(project_config)
-
-
-def test_setup_inference_non_dict_dataset_items(project_config):
-    project_config.trainer.inference_every_epochs = 1
-    project_config.model = cc(
-        "tests.trainers.decoder_trainer_test.GenerativeModel",
-        vocab_size=10,
-        hidden_size=8,
-    )
-    project_config.data.train.dataset = cc(
-        "tests.trainers.decoder_trainer_test.NonDictDataset",
-        size=16,
-        seq_len=4,
-        vocab_size=10,
-    )
-    with pytest.raises(
-        ValueError,
-        match="dataset items must be dicts with",
-    ):
-        create_trainer_from_config(project_config)
-
-
 def test_setup_inference_and_log_success(project_config, temp_run_dir):
     project_config.trainer.inference_every_epochs = 1
     project_config.trainer.max_inference_new_tokens = 32
@@ -654,6 +612,7 @@ def test_setup_inference_and_log_success(project_config, temp_run_dir):
         hidden_size=8,
     )
     transform = cc("tests.trainers.decoder_trainer_test.DummyTransform")
+    collate = cc("trainite.models.transformer.CausalLMCollateFn")
     project_config.data.train.dataset = cc(
         "tests.trainers.decoder_trainer_test.GenerativeDataset",
         size=16,
@@ -661,6 +620,7 @@ def test_setup_inference_and_log_success(project_config, temp_run_dir):
         vocab_size=10,
     )
     project_config.data.train.transform = transform
+    project_config.data.train.dataloader.collate_fn = collate
     project_config.data.val.dataset = cc(
         "tests.trainers.decoder_trainer_test.GenerativeDataset",
         size=8,
@@ -668,6 +628,7 @@ def test_setup_inference_and_log_success(project_config, temp_run_dir):
         vocab_size=10,
     )
     project_config.data.val.transform = transform
+    project_config.data.val.dataloader.collate_fn = collate
     trainer = create_trainer_from_config(project_config)
     assert trainer.max_inference_new_tokens == 32
     trainer.run()

--- a/trainite/datasets/string_reverse.py
+++ b/trainite/datasets/string_reverse.py
@@ -123,6 +123,23 @@ class StringReverseDataset(Dataset):
         }
 
 
+class DatapointModel(BaseModel):
+    """Contract for a causal-LM transformed item: training tensors + the eval prompt.
+
+    Convention: every causal-LM dataset transform returns this shape. The collate
+    fn batches the `train_*`/`attention_mask` fields; the trainer's inference loop
+    reads `eval_input_ids`/`source`/`target` directly.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    source: str
+    target: str
+    train_input_ids: torch.Tensor
+    train_label_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    eval_input_ids: torch.Tensor
+
+
 class PromptCompletionTransform:
     def __init__(self, tokenizer: Any, ignore_index: int = -100) -> None:
         self.tokenizer = tokenizer
@@ -135,7 +152,7 @@ class PromptCompletionTransform:
         source_tokens = self.tokenizer(sample["source"], add_special_tokens=False)["input_ids"]
         return [bos] + source_tokens + [sep]
 
-    def __call__(self, sample: dict[str, str]) -> dict[str, torch.Tensor | str]:
+    def __call__(self, sample: dict[str, str]) -> DatapointModel:
         source = sample["source"]
         target = sample["target"]
 
@@ -155,13 +172,14 @@ class PromptCompletionTransform:
 
         attention_mask = torch.ones(len(input_ids), dtype=torch.long)
 
-        return {
-            "input_ids": input_ids,
-            "attention_mask": attention_mask,
-            "labels": labels,
-            "source": source,
-            "target": target,
-        }
+        return DatapointModel(
+            source=source,
+            target=target,
+            train_input_ids=input_ids,
+            train_label_ids=labels,
+            attention_mask=attention_mask,
+            eval_input_ids=torch.tensor(prompt_ids, dtype=torch.long),
+        )
 
 
 class PromptCompletionTransformConfig(BaseModel):

--- a/trainite/models/transformer.py
+++ b/trainite/models/transformer.py
@@ -201,17 +201,14 @@ class CausalLMCollateFn:
         self.pad_token_id = pad_token_id if pad_token_id is not None else tokenizer.pad_token_id
         self.ignore_index = ignore_index
 
-    def __call__(self, batch: list[dict[str, torch.tensor]]) -> dict[str, torch.Tensor]:
+    def __call__(self, batch: list[Any]) -> dict[str, torch.Tensor]:
         input_ids_list = []
         attention_mask_list = []
         labels_list = []
         for item in batch:
-            input_ids = item.get("input_ids")
-            labels = item.get("labels")
-
-            if input_ids is None or labels is None:
-                raise KeyError(f"Dataset item must contain 'input_ids' and 'labels' keys. Got: {list(item.keys())}")
-            attention_mask = item.get("attention_mask", torch.tensor([1] * len(input_ids)))
+            input_ids = item.train_input_ids
+            labels = item.train_label_ids
+            attention_mask = item.attention_mask
 
             # We flip the sequences to have padding on the left, which allows us to use causal masking without modification
             input_ids_list.append(input_ids.flip(0))

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -21,7 +21,7 @@ from ignite.utils import setup_logger
 from pydantic import BaseModel, ConfigDict, Field
 from torch import nn
 from torch.optim.lr_scheduler import LinearLR
-from torch.utils.data import DataLoader, Dataset, Subset, random_split
+from torch.utils.data import DataLoader, Dataset, random_split
 
 from trainite.config.base import (
     DataConfigBase,
@@ -189,9 +189,6 @@ class Trainer:
         vocab_size = resolve_vocab_size(self.tokenizer, config.model)
         self.model = build_model(config.model, self.tokenizer, vocab_size, self.device)
         self.optimizer = instantiate(config.optimizer, params=self.model.parameters())
-        ds = self.train_loader.dataset
-        ds = ds.dataset if isinstance(ds, Subset) else ds
-        self.prompt_transform = getattr(ds, "transform", None)
         self.epochs: int = config.trainer.epochs
         self.grad_clip_norm: float | None = getattr(config.trainer, "grad_clip_norm", None)
         self.inference_every_epochs = config.trainer.inference_every_epochs
@@ -228,9 +225,8 @@ class Trainer:
         # Run evaluations at the end of each epoch to log training and validation metrics
         self.engine.add_event_handler(Events.EPOCH_COMPLETED, self._run_evaluations)
 
-        # Setup inference and attach inference logger if inference logging is enabled
+        # Attach inference logger if inference logging is enabled
         if self.inference_every_epochs is not None:
-            self._setup_inference()
             self.attach_inference_logger()
 
     def _make_run_dir(self) -> Path:
@@ -459,34 +455,6 @@ class Trainer:
             val_metrics["token_accuracy"],
         )
 
-    def _validate_dataloader_for_inference(self, loader: DataLoader, name: str) -> None:
-        dataset = loader.dataset
-        if len(dataset) == 0:
-            raise ValueError(f"{name} dataset is empty. Cannot perform inference logging.")
-        dataset = dataset.dataset if isinstance(dataset, Subset) else dataset
-        item = dataset[0]
-        if not isinstance(item, dict):
-            raise ValueError(f"{name} dataset items must be dicts with 'source' and 'target' keys.")
-        if "source" not in item or "target" not in item:
-            raise ValueError(f"{name} dataset items must contain 'source' and 'target' keys. Got: {list(item.keys())}")
-
-    def _setup_inference(self) -> None:
-        tokenizer: Any = self.tokenizer
-        if not hasattr(tokenizer, "decode") or not callable(tokenizer):
-            raise ValueError("Tokenizer must be callable and implement 'decode' method for inference logging.")
-
-        # Validate active loaders
-        self._validate_dataloader_for_inference(self.train_loader, "Train")
-        self._validate_dataloader_for_inference(self.val_loader, "Val")
-        if self.test_loader is not None:
-            self._validate_dataloader_for_inference(self.test_loader, "Test")
-
-        # The transform supplies the prompt format (source -> token ids)
-        if self.prompt_transform is None or not hasattr(self.prompt_transform, "build_prompt"):
-            raise ValueError(
-                "Inference logging requires the dataset's transform to define build_prompt(sample) -> list[int]."
-            )
-
     def _log_inference(self, engine: Engine, loader: DataLoader, name: str) -> None:
         self.logger.info(f"Epoch {engine.state.epoch}: Running inference on {name} samples...")
 
@@ -496,17 +464,17 @@ class Trainer:
         total_samples = len(dataset)  # type: ignore
         num_samples = min(self.inference_num_samples, total_samples)
 
-        # Build generation prompts via the dataset's transform (validated in _setup_inference).
+        # Read generation prompts straight off the DatapointModel contract.
         prompt_ids_list: list[torch.Tensor] = []
         prompt_attn_list: list[torch.Tensor] = []
         targets: list[str] = []
         sources: list[str] = []
         for i in range(num_samples):
             item = dataset[i]
-            source = item["source"]
-            target = item["target"]
+            source = item.source
+            target = item.target
 
-            input_ids = torch.tensor(self.prompt_transform.build_prompt(item), dtype=torch.long)
+            input_ids = item.eval_input_ids
             attention_mask = torch.ones_like(input_ids, dtype=torch.long)
 
             prompt_ids_list.append(input_ids)


### PR DESCRIPTION
This pull request standardizes the dataset transform and batching pipeline for causal language modeling tasks by introducing a unified `DatapointModel` contract. All transforms now return this model, which encapsulates both the training tensors and the evaluation prompt. The collate function, trainer, and test suites are updated to work with this new structure, removing legacy dictionary-based handling and associated validation logic. This simplifies the codebase and ensures consistency across data processing, batching, and inference logging.

**Core DatapointModel contract and transform changes:**
- Introduced the `DatapointModel` class in `trainite/datasets/string_reverse.py` to encapsulate source/target strings, training tensors, and evaluation prompt for causal-LM tasks. All transforms now return this model instead of a dictionary. [[1]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250R126-R142) [[2]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L138-R155) [[3]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L158-R182)
- Updated test transforms and dataset item creation in `tests/datasets/string_reverse_test.py`, `tests/models/transformer_test.py`, and `tests/trainers/decoder_trainer_test.py` to use `DatapointModel` instead of dicts, ensuring all tests conform to the new contract. [[1]](diffhunk://#diff-c2f4f8b4321a41e2c5a0e98a2f02dcb6035a6ab905de64800706b537c137bcf4L180-R214) [[2]](diffhunk://#diff-6f82c08d9b763ae03bec58afcb3a2855191b40da55e2902ac0ea2268d754a140R11) [[3]](diffhunk://#diff-6f82c08d9b763ae03bec58afcb3a2855191b40da55e2902ac0ea2268d754a140L157-R173) [[4]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627R19) [[5]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L155-R162)

**Collate function and model input changes:**
- Modified `CausalLMCollateFn` in `trainite/models/transformer.py` to batch `DatapointModel` instances, accessing tensor fields directly rather than via dictionary keys.

**Trainer and inference logging simplification:**
- Removed legacy validation and setup logic from `trainite/trainers/decoder_trainer.py` that checked for dict-based dataset items and transform methods. Inference logging now reads prompts and labels directly from the `DatapointModel` fields. [[1]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL192-L194) [[2]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL231-L233) [[3]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL462-L489) [[4]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL499-R477)
- Updated test configuration and dataset setup in `tests/trainers/decoder_trainer_test.py` to use the new transform and collate function, and removed tests related to invalid dict-based dataset items. [[1]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L105-L115) [[2]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L608-L647) [[3]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627R615-R631)

**General code cleanup:**
- Removed unused imports and legacy dataset classes related to dict-based item handling in tests and trainer code. [[1]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL24-R24) [[2]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L105-L115)

This refactor ensures a consistent, type-safe data flow from preprocessing to training and inference, and simplifies maintenance by eliminating legacy code paths.