### PR TITLE
refactor: move code to utils.py

### DIFF
--- a/tests/datasets/string_reverse_test.py
+++ b/tests/datasets/string_reverse_test.py
@@ -9,8 +9,7 @@ from trainite.datasets.string_reverse import (
 )
 from trainite.datasets.transformed import TransformedDataset
 from trainite.preprocessors.char_tokenizer import CharTokenizer
-from trainite.trainers.decoder_trainer import build_dataset
-from trainite.shared.utils import get_target
+from trainite.shared.utils import build_dataset, get_target
 
 
 def test_string_reverse_dataset():

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -18,6 +18,7 @@ from trainite.config import (
 )
 from trainite.datasets.string_reverse import DatapointModel
 from trainite.trainers.decoder_trainer import Trainer, TrainerConfig, ProjectConfig
+from trainite.shared.utils import upload_model_to_wandb
 from ignite.engine import Events
 from ignite.handlers import EarlyStopping
 import ignite.distributed as idist
@@ -387,7 +388,12 @@ def test_upload_model_to_wandb(project_config, temp_run_dir):
     trainer.exp_logger = mock.MagicMock()
     trainer.checkpointers = {"checkpoint_best": mock.MagicMock(last_checkpoint="best_model_1.pt")}
 
-    trainer._upload_model_to_wandb()
+    upload_model_to_wandb(
+        trainer.exp_logger,
+        trainer.checkpointers,
+        trainer.config.output.run_name,
+        trainer.logger,
+    )
 
     trainer.exp_logger.Artifact.return_value.add_file.assert_called_once_with("best_model_1.pt")
     trainer.exp_logger.log_artifact.assert_called_once_with(trainer.exp_logger.Artifact.return_value)
@@ -399,7 +405,12 @@ def test_upload_model_to_wandb_no_checkpoint(project_config):
     trainer.checkpointers = {}  # nothing saved -> skip, don't crash
 
     with mock.patch.object(trainer.logger, "warning") as mock_warning:
-        trainer._upload_model_to_wandb()
+        upload_model_to_wandb(
+            trainer.exp_logger,
+            trainer.checkpointers,
+            trainer.config.output.run_name,
+            trainer.logger,
+        )
 
     trainer.exp_logger.log_artifact.assert_not_called()
     mock_warning.assert_called_once()

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -308,10 +308,16 @@ def _build_templates(model_name: str, dataset_name: str, trainer_name: str, proj
             ]
         )
 
+    shared_repl = [
+        ("trainite.shared.utils", "utils"),
+        ("trainite.config.base", "config"),
+        ("trainite.datasets.transformed", "datasets.transformed"),
+    ]
+
     templates.update(
         {
             "trainer.py": _render_template(PROJECT_ROOT / trainer_spec.implementation_path, trainer_replacements),
-            "utils.py": _render_template(PROJECT_ROOT / "trainite/shared/utils.py"),
+            "utils.py": _render_template(PROJECT_ROOT / "trainite/shared/utils.py", shared_repl),
             "main.py": _render_template(PROJECT_ROOT / "trainite/shared/main.py", main_replacements),
             "README.md": _render_template(PROJECT_ROOT / "trainite/templates/project/README.md", readme_replacements),
             "config.py": _render_template(PROJECT_ROOT / "trainite/config/base.py", config_replacements),

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -363,7 +363,7 @@ def upload_model_to_wandb(
     run_name: str,
     logger: logging.Logger,
 ) -> None:
-    checkpoint = checkpointers.get("checkpoint_best") or checkpointers.get("checkpoint_last")
+    checkpoint = checkpointers.get("checkpoint_best")
     checkpoint_path = checkpoint.last_checkpoint if checkpoint else None
     if not checkpoint_path:
         logger.warning("No checkpoint found; skipping model upload to Weights & Biases.")

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -1,10 +1,35 @@
+from datetime import datetime
 import importlib
+import inspect
+import logging
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
-import yaml
+from ignite.engine import Engine, Events
+from ignite.handlers import (
+    Checkpoint,
+    DiskSaver,
+    EarlyStopping,
+    create_lr_scheduler_with_warmup,
+)
+from ignite.handlers.fbresearch_logger import FBResearchLogger
+from ignite.handlers.param_scheduler import ParamScheduler
+from ignite.handlers.tensorboard_logger import TensorboardLogger
+from ignite.handlers.wandb_logger import WandBLogger
+from ignite.utils import setup_logger
 from omegaconf import OmegaConf
 from pydantic import BaseModel
+import torch
+from torch import nn
+from torch.optim.lr_scheduler import LinearLR
+from torch.utils.data import DataLoader, Dataset, random_split
+import yaml
+
+from trainite.config.base import (
+    DataConfigBase,
+    DataWithAutoSplit,
+)
+from trainite.datasets.transformed import TransformedDataset
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -72,3 +97,301 @@ def dump_config(config: BaseModel, path: str | Path) -> None:
 def load_config(path: str | Path, config_cls: type[T]) -> T:
     raw_conf = OmegaConf.load(path)
     return config_cls.model_validate(raw_conf)
+
+
+# ==========================================
+# Builders (Dataset, Dataloader, Model Setup)
+# ==========================================
+
+
+# Inspects the target symbol's signature and filters the candidates to
+# only include those that are accepted by the target symbol.
+def _inject_if_accepted(target_symbol: Any, **candidates: Any) -> dict[str, Any]:
+    try:
+        sig = inspect.signature(target_symbol)
+        return {k: v for k, v in candidates.items() if k in sig.parameters}
+    except Exception:
+        return {}
+
+
+# Builds the model based on the provided configuration, tokenizer, and device.
+def build_model(model_config: Any, tokenizer: Any, vocab_size: int, device: str | torch.device) -> nn.Module:
+    target_symbol = get_target(model_config.target)
+    kwargs = _inject_if_accepted(
+        target_symbol,
+        vocab_size=vocab_size,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+    model = instantiate(model_config, **kwargs)
+    model.to(device)
+    return model
+
+
+def build_dataset(dataset_config: Any, transform_config: Any, tokenizer: Any) -> Dataset:
+    ds = get_target(dataset_config.target)
+    dataset = instantiate(dataset_config, **_inject_if_accepted(ds, preprocessor=tokenizer, tokenizer=tokenizer))
+    transform = None
+    if transform_config is not None:
+        tf = get_target(transform_config.target)
+        transform = instantiate(
+            transform_config, **_inject_if_accepted(tf, preprocessor=tokenizer, tokenizer=tokenizer)
+        )
+    # Wraps the dataset with the transform if provided, otherwise returns the dataset as is.
+    return TransformedDataset(dataset, transform)
+
+
+def create_dataloader(
+    dataset: Dataset,
+    dl_config: Any,
+    tokenizer: Any,
+    shuffle: bool | None = None,
+) -> DataLoader:
+    dl_kwargs = dl_config.model_dump(exclude={"collate_fn", "shuffle"})
+    if shuffle is None:
+        shuffle = getattr(dl_config, "shuffle", False)
+    collate_fn = None
+    collate_config = dl_config.collate_fn
+    if collate_config:
+        target_symbol = get_target(collate_config.target)
+        if isinstance(target_symbol, type):
+            collate_fn = instantiate(collate_config, tokenizer=tokenizer)
+        else:
+            collate_fn = target_symbol
+    return DataLoader(dataset, shuffle=shuffle, collate_fn=collate_fn, **dl_kwargs)
+
+
+def _loaders_from_splits(
+    data_config: DataConfigBase, tokenizer: Any
+) -> tuple[DataLoader, DataLoader, DataLoader | None]:
+    def _make(split_config: Any) -> DataLoader:
+        ds = build_dataset(split_config.dataset, split_config.transform, tokenizer)
+        return create_dataloader(ds, split_config.dataloader, tokenizer)
+
+    return _make(data_config.train), _make(data_config.val), _make(data_config.test) if data_config.test else None
+
+
+def _loaders_from_ratios(
+    data_config: DataWithAutoSplit, tokenizer: Any, seed: int
+) -> tuple[DataLoader, DataLoader, DataLoader | None]:
+    dataset = build_dataset(data_config.dataset, data_config.transform, tokenizer)
+    total_len = len(dataset)  # type: ignore
+    if total_len == 0:
+        raise ValueError("Training dataset is empty. Cannot perform train/val/test split.")
+    val_ratio = data_config.val_ratio
+    test_ratio = data_config.test_ratio
+    train_len = int(total_len * (1.0 - test_ratio - val_ratio))
+    val_len = int(total_len * val_ratio)
+    test_len = total_len - train_len - val_len
+    train_ds, val_ds, test_ds = random_split(
+        dataset,
+        [train_len, val_len, test_len],
+        generator=torch.Generator().manual_seed(seed),
+    )
+    dl = data_config.dataloader
+    return (
+        create_dataloader(train_ds, dl, tokenizer, shuffle=True),
+        create_dataloader(val_ds, dl, tokenizer, shuffle=False),
+        create_dataloader(test_ds, dl, tokenizer, shuffle=False) if test_len > 0 else None,
+    )
+
+
+def build_dataloaders(data_config: Any, tokenizer: Any, seed: int) -> tuple[DataLoader, DataLoader, DataLoader | None]:
+    if isinstance(data_config, DataWithAutoSplit):
+        return _loaders_from_ratios(data_config, tokenizer, seed)
+    return _loaders_from_splits(data_config, tokenizer)
+
+
+# ==========================================
+# Handlers (Ignite Engine Wiring & Setup)
+# ==========================================
+
+
+def make_run_dir(output_config: Any) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_name = output_config.run_name
+    run_dir = Path(output_config.root) / run_name / timestamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def attach_lr_scheduler(
+    engine: Engine,
+    optimizer: Any,
+    total_iters: int,
+    peak_lr: float,
+) -> ParamScheduler:
+    warmup_iters = max(2, int(0.1 * total_iters))
+    linear_decay = LinearLR(
+        optimizer,
+        start_factor=1.0,
+        end_factor=0.0,
+        total_iters=total_iters - warmup_iters,
+    )
+    scheduler: ParamScheduler = create_lr_scheduler_with_warmup(
+        linear_decay,
+        warmup_start_value=0.0,
+        warmup_end_value=peak_lr,
+        warmup_duration=warmup_iters,
+    )
+    engine.add_event_handler(Events.ITERATION_COMPLETED, scheduler)
+    return scheduler
+
+
+def attach_early_stopping(
+    val_evaluator: Engine,
+    trainer_engine: Engine,
+    patience: int | None,
+) -> EarlyStopping | None:
+    if patience is not None:
+        early_stopping = EarlyStopping(
+            patience=patience,
+            score_function=lambda engine: engine.state.metrics["loss"],
+            trainer=trainer_engine,
+            min_delta=0.0,
+            mode="min",
+        )
+        val_evaluator.add_event_handler(Events.COMPLETED, early_stopping)
+        return early_stopping
+    return None
+
+
+def setup_checkpointing(
+    engine: Engine,
+    val_evaluator: Engine,
+    to_save: dict[str, Any],
+    run_dir: Path,
+) -> dict[str, Checkpoint]:
+    checkpointers = {}
+
+    def score_function(engine_val):
+        loss = engine_val.state.metrics["loss"]
+        return -loss
+
+    checkpoint = Checkpoint(
+        to_save=to_save,
+        save_handler=DiskSaver(dirname=str(run_dir), require_empty=False),
+        filename_prefix="best",
+        score_function=score_function,
+        score_name="val_loss",
+        n_saved=1,
+        global_step_transform=lambda *_: engine.state.iteration,
+    )
+    val_evaluator.add_event_handler(Events.COMPLETED, checkpoint)
+    checkpointers["checkpoint_best"] = checkpoint
+
+    last_checkpoint = Checkpoint(
+        to_save=to_save,
+        save_handler=DiskSaver(dirname=str(run_dir), require_empty=False),
+        filename_prefix="last",
+        n_saved=1,
+        global_step_transform=lambda *_: engine.state.iteration,
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, last_checkpoint)
+
+    checkpointers["checkpoint_last"] = last_checkpoint
+    return checkpointers
+
+
+def setup_experiment_logger(
+    backend: Literal["tensorboard", "wandb"],
+    engine: Engine,
+    val_evaluator: Engine,
+    train_evaluator: Engine,
+    test_evaluator: Engine,
+    optimizer: Any,
+    run_dir: Path,
+    metric_names: list[str],
+    has_test: bool,
+    run_name: str,
+) -> TensorboardLogger | WandBLogger:
+    if backend == "wandb":
+        exp_logger: TensorboardLogger | WandBLogger = WandBLogger(
+            project=run_name, dir=str(run_dir), name=str(run_dir).split("/")[-1]
+        )
+    else:
+        log_dir = run_dir / "tensorboard" if run_dir else None
+        exp_logger = TensorboardLogger(log_dir=log_dir)
+
+    # Log training iteration loss
+    exp_logger.attach_output_handler(
+        engine,
+        event_name=Events.ITERATION_COMPLETED,
+        tag="training",
+        output_transform=lambda output: {"batch_loss": output["loss"]},
+    )
+
+    # Log training epoch metrics
+    exp_logger.attach_output_handler(
+        train_evaluator,
+        event_name=Events.EPOCH_COMPLETED,
+        tag="training",
+        metric_names=metric_names,
+        global_step_transform=lambda *_: engine.state.iteration,
+    )
+
+    # Log validation epoch metrics
+    exp_logger.attach_output_handler(
+        val_evaluator,
+        event_name=Events.EPOCH_COMPLETED,
+        tag="validation",
+        metric_names=metric_names,
+        global_step_transform=lambda *_: engine.state.iteration,
+    )
+
+    # Log test metrics if applicable
+    if has_test:
+        exp_logger.attach_output_handler(
+            test_evaluator,
+            event_name=Events.COMPLETED,
+            tag="testing",
+            metric_names=metric_names,
+            global_step_transform=lambda *_: engine.state.iteration,
+        )
+
+    # Log optimizer learning rates
+    exp_logger.attach_opt_params_handler(
+        engine,
+        event_name=Events.ITERATION_STARTED,
+        optimizer=optimizer,
+    )
+    return exp_logger
+
+
+def upload_model_to_wandb(
+    exp_logger: Any,
+    checkpointers: dict[str, Checkpoint],
+    run_name: str,
+    logger: logging.Logger,
+) -> None:
+    checkpoint = checkpointers.get("checkpoint_best") or checkpointers.get("checkpoint_last")
+    checkpoint_path = checkpoint.last_checkpoint if checkpoint else None
+    if not checkpoint_path:
+        logger.warning("No checkpoint found; skipping model upload to Weights & Biases.")
+        return
+    artifact = exp_logger.Artifact(name=f"{run_name}-model".replace("/", "-"), type="model")
+    artifact.add_file(str(checkpoint_path))
+    exp_logger.log_artifact(artifact)
+    logger.info("Uploaded model checkpoint to Weights & Biases: %s", checkpoint_path)
+
+
+def setup_console_logger(
+    run_dir: Path,
+    engine: Engine,
+    log_every_steps: int,
+    optimizer: Any,
+) -> logging.Logger:
+    logger = setup_logger(
+        "trainer",
+        level=logging.INFO,
+        filepath=str(run_dir / "output.log") if run_dir else None,
+        reset=True,
+    )
+    train_fb_logger = FBResearchLogger(logger=logger, show_output=True)
+    train_fb_logger.attach(
+        engine,
+        name="Train",
+        every=log_every_steps,
+        optimizer=optimizer,
+        output_transform=lambda output: {"loss": output["loss"].item()},
+    )
+    return logger

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -305,9 +305,7 @@ def setup_experiment_logger(
     run_name: str,
 ) -> TensorboardLogger | WandBLogger:
     if backend == "wandb":
-        exp_logger: TensorboardLogger | WandBLogger = WandBLogger(
-            project=run_name, dir=str(run_dir), name=str(run_dir).split("/")[-1]
-        )
+        exp_logger = WandBLogger(project=run_name, dir=str(run_dir), name=str(run_dir).split("/")[-1])
     else:
         log_dir = run_dir / "tensorboard" if run_dir else None
         exp_logger = TensorboardLogger(log_dir=log_dir)

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -113,7 +113,7 @@ class Trainer:
         self.logger = setup_console_logger(self.run_dir, self.engine, config.trainer.log_every_steps, self.optimizer)
 
         # Attach learning rate scheduler
-        self.scheduler = attach_lr_scheduler(self.engine, self.optimizer, self.total_iters, config.optimizer.lr)
+        attach_lr_scheduler(self.engine, self.optimizer, self.total_iters, config.optimizer.lr)
 
         # Attach early stopping
         attach_early_stopping(self.val_evaluator, self.engine, config.trainer.early_stopping_patience)

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -1,28 +1,14 @@
-import inspect
 import logging
-from datetime import datetime
-from pathlib import Path
 from typing import Any, Literal
 
 import torch
-from ignite.engine import Engine, Events
-from ignite.handlers import (
-    Checkpoint,
-    DiskSaver,
-    EarlyStopping,
-    create_lr_scheduler_with_warmup,
-)
 import ignite.distributed as idist
-from ignite.handlers.fbresearch_logger import FBResearchLogger
-from ignite.handlers.param_scheduler import ParamScheduler
-from ignite.handlers.tensorboard_logger import TensorboardLogger
-from ignite.handlers.wandb_logger import WandBLogger
+from ignite.engine import Engine, Events
 from ignite.metrics import Accuracy, Loss, Metric, RunningAverage
 from ignite.utils import setup_logger
 from pydantic import BaseModel, ConfigDict, Field
 from torch import nn
-from torch.optim.lr_scheduler import LinearLR
-from torch.utils.data import DataLoader, Dataset, random_split
+from torch.utils.data import DataLoader
 
 from trainite.config.base import (
     DataConfigBase,
@@ -30,12 +16,23 @@ from trainite.config.base import (
     OptimizerConfig,
     OutputConfig,
 )
-from trainite.datasets.transformed import TransformedDataset
 
 # __MODEL_IMPORT__
 # __DATASET_IMPORT__
 # __PREPROCESSOR_IMPORT__
-from trainite.shared.utils import dump_config, get_target, instantiate
+from trainite.shared.utils import (
+    attach_early_stopping,
+    attach_lr_scheduler,
+    build_dataloaders,
+    build_model,
+    dump_config,
+    instantiate,
+    make_run_dir,
+    setup_checkpointing,
+    setup_console_logger,
+    setup_experiment_logger,
+    upload_model_to_wandb,
+)
 
 
 class TrainerConfig(BaseModel):
@@ -82,103 +79,6 @@ def resolve_vocab_size(tokenizer: Any, model_config: Any) -> int:
     return vocab_size
 
 
-# Inspects the target symbol's signature and filters the candidates to
-# only include those that are accepted by the target symbol.
-def _inject_if_accepted(target_symbol: Any, **candidates: Any) -> dict[str, Any]:
-    try:
-        sig = inspect.signature(target_symbol)
-        return {k: v for k, v in candidates.items() if k in sig.parameters}
-    except Exception:
-        return {}
-
-
-# Builds the model based on the provided configuration, tokenizer, and device.
-def build_model(model_config: Any, tokenizer: Any, vocab_size: int, device: str | torch.device) -> nn.Module:
-    target_symbol = get_target(model_config.target)
-    kwargs = _inject_if_accepted(
-        target_symbol,
-        vocab_size=vocab_size,
-        pad_token_id=tokenizer.pad_token_id,
-    )
-    model = instantiate(model_config, **kwargs)
-    model.to(device)
-    return model
-
-
-def build_dataset(dataset_config: Any, transform_config: Any, tokenizer: Any) -> Dataset:
-    ds = get_target(dataset_config.target)
-    dataset = instantiate(dataset_config, **_inject_if_accepted(ds, preprocessor=tokenizer, tokenizer=tokenizer))
-    transform = None
-    if transform_config is not None:
-        tf = get_target(transform_config.target)
-        transform = instantiate(
-            transform_config, **_inject_if_accepted(tf, preprocessor=tokenizer, tokenizer=tokenizer)
-        )
-    # Wraps the dataset with the transform if provided, otherwise returns the dataset as is.
-    return TransformedDataset(dataset, transform)
-
-
-def create_dataloader(
-    dataset: Dataset,
-    dl_config: Any,
-    tokenizer: Any,
-    shuffle: bool | None = None,
-) -> DataLoader:
-    dl_kwargs = dl_config.model_dump(exclude={"collate_fn", "shuffle"})
-    if shuffle is None:
-        shuffle = getattr(dl_config, "shuffle", False)
-    collate_fn = None
-    collate_config = dl_config.collate_fn
-    if collate_config:
-        target_symbol = get_target(collate_config.target)
-        if isinstance(target_symbol, type):
-            collate_fn = instantiate(collate_config, tokenizer=tokenizer)
-        else:
-            collate_fn = target_symbol
-    return DataLoader(dataset, shuffle=shuffle, collate_fn=collate_fn, **dl_kwargs)
-
-
-def _loaders_from_splits(
-    data_config: DataConfigBase, tokenizer: Any
-) -> tuple[DataLoader, DataLoader, DataLoader | None]:
-    def _make(split_config: Any) -> DataLoader:
-        ds = build_dataset(split_config.dataset, split_config.transform, tokenizer)
-        return create_dataloader(ds, split_config.dataloader, tokenizer)
-
-    return _make(data_config.train), _make(data_config.val), _make(data_config.test) if data_config.test else None
-
-
-def _loaders_from_ratios(
-    data_config: DataWithAutoSplit, tokenizer: Any, seed: int
-) -> tuple[DataLoader, DataLoader, DataLoader | None]:
-    dataset = build_dataset(data_config.dataset, data_config.transform, tokenizer)
-    total_len = len(dataset)  # type: ignore
-    if total_len == 0:
-        raise ValueError("Training dataset is empty. Cannot perform train/val/test split.")
-    val_ratio = data_config.val_ratio
-    test_ratio = data_config.test_ratio
-    train_len = int(total_len * (1.0 - test_ratio - val_ratio))
-    val_len = int(total_len * val_ratio)
-    test_len = total_len - train_len - val_len
-    train_ds, val_ds, test_ds = random_split(
-        dataset,
-        [train_len, val_len, test_len],
-        generator=torch.Generator().manual_seed(seed),
-    )
-    dl = data_config.dataloader
-    return (
-        create_dataloader(train_ds, dl, tokenizer, shuffle=True),
-        create_dataloader(val_ds, dl, tokenizer, shuffle=False),
-        create_dataloader(test_ds, dl, tokenizer, shuffle=False) if test_len > 0 else None,
-    )
-
-
-def build_dataloaders(data_config: Any, tokenizer: Any, seed: int) -> tuple[DataLoader, DataLoader, DataLoader | None]:
-    if isinstance(data_config, DataWithAutoSplit):
-        return _loaders_from_ratios(data_config, tokenizer, seed)
-    return _loaders_from_splits(data_config, tokenizer)
-
-
 class Trainer:
     def __init__(self, config: ProjectConfig) -> None:
         self.logger: logging.Logger = setup_logger("trainer", level=logging.INFO)
@@ -199,7 +99,6 @@ class Trainer:
         self.max_inference_new_tokens = config.trainer.max_inference_new_tokens
         self.loss_fn: nn.CrossEntropyLoss = nn.CrossEntropyLoss()
         self.total_iters: int = len(self.train_loader) * self.epochs
-        self.checkpointers: dict[str, Checkpoint] = {}
         self.engine = Engine(self._train_step)
         self.train_evaluator = Engine(self._eval_step)
         self.val_evaluator = Engine(self._eval_step)
@@ -207,23 +106,39 @@ class Trainer:
         self.metrics: dict = self._attach_metrics()
 
         # Create run directory for outputs
-        self.run_dir = self._make_run_dir()
+        self.run_dir = make_run_dir(config.output)
         dump_config(self.config, self.run_dir / "config.yaml")
 
         # Attach loggers for console
-        self.logger = self.attach_loggers()
+        self.logger = setup_console_logger(self.run_dir, self.engine, config.trainer.log_every_steps, self.optimizer)
 
         # Attach learning rate scheduler
-        self.attach_lr_scheduler()
+        self.scheduler = attach_lr_scheduler(self.engine, self.optimizer, self.total_iters, config.optimizer.lr)
 
         # Attach early stopping
-        self.setup_early_stopping()
+        attach_early_stopping(self.val_evaluator, self.engine, config.trainer.early_stopping_patience)
 
         # Attach checkpointing
-        self.checkpointers = self.setup_checkpointing()
+        self.checkpointers = setup_checkpointing(
+            self.engine,
+            self.val_evaluator,
+            {"model": self.model, "optimizer": self.optimizer},
+            self.run_dir,
+        )
 
         # Attach experiment logger (TensorBoard or Weights & Biases)
-        self.exp_logger = self._setup_experiment_logger()
+        self.exp_logger = setup_experiment_logger(
+            config.logger,
+            self.engine,
+            self.val_evaluator,
+            self.train_evaluator,
+            self.test_evaluator,
+            self.optimizer,
+            self.run_dir,
+            ["loss", "token_accuracy"],
+            bool(self.test_loader),
+            config.output.run_name,
+        )
 
         # Run evaluations at the end of each epoch to log training and validation metrics
         self.engine.add_event_handler(Events.EPOCH_COMPLETED, self._run_evaluations)
@@ -231,13 +146,6 @@ class Trainer:
         # Attach inference logger if inference logging is enabled
         if self.inference_every_epochs is not None:
             self.attach_inference_logger()
-
-    def _make_run_dir(self) -> Path:
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        run_name = self.config.output.run_name
-        run_dir = Path(self.config.output.root) / run_name / timestamp
-        run_dir.mkdir(parents=True, exist_ok=True)
-        return run_dir
 
     def _flatten(self, output: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         logits = output["logits"].reshape(-1, output["logits"].size(-1))
@@ -299,39 +207,6 @@ class Trainer:
 
         return metrics
 
-    def attach_loggers(self) -> logging.Logger:
-        logger = setup_logger(
-            "trainer",
-            level=logging.INFO,
-            filepath=str(self.run_dir / "output.log") if self.run_dir else None,
-            reset=True,
-        )
-        train_fb_logger: FBResearchLogger = FBResearchLogger(logger=logger, show_output=True)
-        train_fb_logger.attach(
-            self.engine,
-            name="Train",
-            every=self.config.trainer.log_every_steps,
-            optimizer=self.optimizer,
-            output_transform=lambda output: {"loss": output["loss"].item()},
-        )
-        return logger
-
-    def attach_lr_scheduler(self) -> None:
-        warmup_iters = max(2, int(0.1 * self.total_iters))
-        linear_decay = LinearLR(
-            self.optimizer,
-            start_factor=1.0,
-            end_factor=0.0,
-            total_iters=self.total_iters - warmup_iters,
-        )
-        self.scheduler: ParamScheduler = create_lr_scheduler_with_warmup(
-            linear_decay,
-            warmup_start_value=0.0,
-            warmup_end_value=self.config.optimizer.lr,
-            warmup_duration=warmup_iters,
-        )
-        self.engine.add_event_handler(Events.ITERATION_COMPLETED, self.scheduler)
-
     def attach_inference_logger(self) -> None:
         self.engine.add_event_handler(
             Events.EPOCH_COMPLETED(every=self.inference_every_epochs),
@@ -346,105 +221,6 @@ class Trainer:
             self.val_loader,
             "Val",
         )
-
-    def setup_early_stopping(self) -> None:
-        patience = self.config.trainer.early_stopping_patience
-        if patience is not None:
-            early_stopping = EarlyStopping(
-                patience=patience,
-                score_function=lambda engine: engine.state.metrics["loss"],
-                trainer=self.engine,
-                min_delta=0.0,
-                mode="min",
-            )
-            self.val_evaluator.add_event_handler(Events.COMPLETED, early_stopping)
-
-    def setup_checkpointing(self) -> dict[str, Checkpoint]:
-        to_save = {"model": self.model, "optimizer": self.optimizer}
-        checkpointers = {}
-
-        def score_function(engine):
-            loss = engine.state.metrics["loss"]
-            return -loss
-
-        checkpoint = Checkpoint(
-            to_save=to_save,
-            save_handler=DiskSaver(dirname=str(self.run_dir), require_empty=False),
-            filename_prefix="best",
-            score_function=score_function,
-            score_name="val_loss",
-            n_saved=1,
-            global_step_transform=lambda *_: self.engine.state.iteration,
-        )
-        self.val_evaluator.add_event_handler(Events.COMPLETED, checkpoint)
-        checkpointers["checkpoint_best"] = checkpoint
-
-        last_checkpoint = Checkpoint(
-            to_save=to_save,
-            save_handler=DiskSaver(dirname=str(self.run_dir), require_empty=False),
-            filename_prefix="last",
-            n_saved=1,
-            global_step_transform=lambda *_: self.engine.state.iteration,
-        )
-        self.engine.add_event_handler(Events.EPOCH_COMPLETED, last_checkpoint)
-
-        checkpointers["checkpoint_last"] = last_checkpoint
-        return checkpointers
-
-    def _setup_experiment_logger(self) -> TensorboardLogger | WandBLogger:
-        if self.config.logger == "wandb":
-            exp_logger: TensorboardLogger | WandBLogger = WandBLogger(
-                project=self.config.output.run_name, dir=str(self.run_dir), name=str(self.run_dir).split("/")[-1]
-            )
-
-        else:
-            log_dir = self.run_dir / "tensorboard" if self.run_dir else None
-            exp_logger = TensorboardLogger(log_dir=log_dir)
-        metric_names = ["loss", "token_accuracy"]
-
-        # Log training iteration loss
-        exp_logger.attach_output_handler(
-            self.engine,
-            event_name=Events.ITERATION_COMPLETED,
-            tag="training",
-            output_transform=lambda output: {"batch_loss": output["loss"]},
-        )
-
-        # Log training epoch metrics
-        exp_logger.attach_output_handler(
-            self.train_evaluator,
-            event_name=Events.EPOCH_COMPLETED,
-            tag="training",
-            metric_names=metric_names,
-            global_step_transform=lambda *_: self.engine.state.iteration,
-        )
-
-        # Log validation epoch metrics
-        exp_logger.attach_output_handler(
-            self.val_evaluator,
-            event_name=Events.EPOCH_COMPLETED,
-            tag="validation",
-            metric_names=metric_names,
-            global_step_transform=lambda *_: self.engine.state.iteration,
-        )
-
-        # Log test metrics if applicable
-        if self.test_loader:
-            exp_logger.attach_output_handler(
-                self.test_evaluator,
-                event_name=Events.COMPLETED,
-                tag="testing",
-                metric_names=metric_names,
-                global_step_transform=lambda *_: self.engine.state.iteration,
-            )
-
-        # Log optimizer learning rates
-        exp_logger.attach_opt_params_handler(
-            self.engine,
-            event_name=Events.ITERATION_STARTED,
-            optimizer=self.optimizer,
-        )
-        return exp_logger
 
     def _log_text(self, tag: str, text: str, step: int) -> None:
         # Both backends escape HTML in the caller; wandb renders it, TB uses markdown.
@@ -656,18 +432,11 @@ class Trainer:
             self.test()
 
         if self.config.logger == "wandb":
-            self._upload_model_to_wandb()
+            upload_model_to_wandb(
+                self.exp_logger,
+                self.checkpointers,
+                self.config.output.run_name,
+                self.logger,
+            )
 
         self.exp_logger.close()
-
-    def _upload_model_to_wandb(self) -> None:
-        checkpoint = self.checkpointers.get("checkpoint_best") or self.checkpointers.get("checkpoint_last")
-        checkpoint_path = checkpoint.last_checkpoint if checkpoint else None
-        if not checkpoint_path:
-            self.logger.warning("No checkpoint found; skipping model upload to Weights & Biases.")
-            return
-        # WandBLogger forwards attribute access to the wandb module (same as .log/.Html used above).
-        artifact = self.exp_logger.Artifact(name=f"{self.config.output.run_name}-model".replace("/", "-"), type="model")
-        artifact.add_file(str(checkpoint_path))
-        self.exp_logger.log_artifact(artifact)
-        self.logger.info("Uploaded model checkpoint to Weights & Biases: %s", checkpoint_path)


### PR DESCRIPTION
This pull request refactors and centralizes shared utility functions for dataset, dataloader, model setup, and Ignite engine wiring into a new `trainite/shared/utils.py` module. It updates the `Trainer` class in `decoder_trainer.py` and related tests to use these shared utilities, resulting in a cleaner and more maintainable codebase. The changes also improve code reuse and consistency across the project.

**Refactoring and Centralization of Utilities:**

* Moved all builder and Ignite engine setup functions (such as `build_model`, `build_dataset`, `create_dataloader`, `build_dataloaders`, `make_run_dir`, `attach_lr_scheduler`, `attach_early_stopping`, `setup_checkpointing`, `setup_experiment_logger`, `upload_model_to_wandb`, and `setup_console_logger`) from `decoder_trainer.py` into a new shared file, `trainite/shared/utils.py`. All related imports and usages were updated accordingly. [[1]](diffhunk://#diff-95664947e337a24cae1f3e4435b2f7c9583235285155de1ca6447fa7b50257bdR1-R32) [[2]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL1-R35) [[3]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL85-L181) [[4]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL202-R141) [[5]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL235-L241)

**Trainer Initialization and Logging Improvements:**

* The `Trainer` class in `decoder_trainer.py` now uses the shared utility functions for run directory creation, logger setup, learning rate scheduling, early stopping, checkpointing, and experiment logging, removing duplicated code and improving clarity. [[1]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL202-R141) [[2]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL235-L241)

**Test Refactoring:**

* Updated tests to import and use the new `build_dataset` and `upload_model_to_wandb` utilities from `trainite.shared.utils` instead of the old locations. This includes changes in both `tests/datasets/string_reverse_test.py` and `tests/trainers/decoder_trainer_test.py`. [[1]](diffhunk://#diff-c2f4f8b4321a41e2c5a0e98a2f02dcb6035a6ab905de64800706b537c137bcf4L12-R12) [[2]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627R21) [[3]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L390-R396) [[4]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L402-R413)

**CLI Template Generation:**

* Updated the CLI initialization logic in `trainite/cli/init.py` to use a replacement mapping when rendering the shared `utils.py` template, ensuring correct import paths in generated projects.

These changes improve maintainability, encourage code reuse, and make it easier to add new trainers or datasets while keeping the codebase DRY and organized.