### PR TITLE
split setup_checkpointing

### DIFF
--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -393,29 +393,12 @@ def test_upload_model_to_wandb(mock_setup, project_config, temp_run_dir):
     trainer.checkpointers.clear()
     trainer.checkpointers["checkpoint_best"] = mock.MagicMock(last_checkpoint="best_model_1.pt")
 
-    with mock.patch("pathlib.Path.exists", return_value=True):
-        from ignite.handlers.checkpoint import CheckpointEvents
-
-        trainer.val_evaluator.fire_event(CheckpointEvents.SAVED_CHECKPOINT)
-
-    mock_logger.Artifact.return_value.add_file.assert_called_once_with("best_model_1.pt")
-    mock_logger.log_artifact.assert_called_once_with(mock_logger.Artifact.return_value)
-
-
-@mock.patch("trainite.trainers.decoder_trainer.setup_experiment_tracking")
-def test_upload_model_to_wandb_no_checkpoint(mock_setup, project_config):
-    project_config.logger = "wandb"
-    mock_logger = mock.MagicMock()
-    mock_setup.return_value = mock_logger
-
-    trainer = create_trainer_from_config(project_config)
-    trainer.checkpointers.clear()
-
     from ignite.handlers.checkpoint import CheckpointEvents
 
     trainer.val_evaluator.fire_event(CheckpointEvents.SAVED_CHECKPOINT)
 
-    mock_logger.log_artifact.assert_not_called()
+    mock_logger.Artifact.return_value.add_file.assert_called_once_with("best_model_1.pt")
+    mock_logger.log_artifact.assert_called_once_with(mock_logger.Artifact.return_value)
 
 
 @mock.patch("trainite.trainers.decoder_trainer.setup_experiment_tracking")
@@ -428,10 +411,9 @@ def test_upload_last_checkpoint_to_wandb(mock_setup, project_config, temp_run_di
     trainer.checkpointers.clear()
     trainer.checkpointers["checkpoint_last"] = mock.MagicMock(last_checkpoint="last_model_1.pt")
 
-    with mock.patch("pathlib.Path.exists", return_value=True):
-        from ignite.handlers.checkpoint import CheckpointEvents
+    from ignite.handlers.checkpoint import CheckpointEvents
 
-        trainer.trainer.fire_event(CheckpointEvents.SAVED_CHECKPOINT)
+    trainer.trainer.fire_event(CheckpointEvents.SAVED_CHECKPOINT)
 
     mock_logger.Artifact.return_value.add_file.assert_called_once_with("last_model_1.pt")
     mock_logger.log_artifact.assert_called_once_with(mock_logger.Artifact.return_value)

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -390,7 +390,8 @@ def test_upload_model_to_wandb(mock_setup, project_config, temp_run_dir):
     mock_setup.return_value = mock_logger
 
     trainer = create_trainer_from_config(project_config)
-    trainer.checkpointers = {"checkpoint_best": mock.MagicMock(last_checkpoint="best_model_1.pt")}
+    trainer.checkpointers.clear()
+    trainer.checkpointers["checkpoint_best"] = mock.MagicMock(last_checkpoint="best_model_1.pt")
 
     with mock.patch("pathlib.Path.exists", return_value=True):
         from ignite.handlers.checkpoint import CheckpointEvents
@@ -408,7 +409,7 @@ def test_upload_model_to_wandb_no_checkpoint(mock_setup, project_config):
     mock_setup.return_value = mock_logger
 
     trainer = create_trainer_from_config(project_config)
-    trainer.checkpointers = {}  # nothing saved
+    trainer.checkpointers.clear()
 
     from ignite.handlers.checkpoint import CheckpointEvents
 
@@ -424,7 +425,8 @@ def test_upload_last_checkpoint_to_wandb(mock_setup, project_config, temp_run_di
     mock_setup.return_value = mock_logger
 
     trainer = create_trainer_from_config(project_config)
-    trainer.checkpointers = {"checkpoint_last": mock.MagicMock(last_checkpoint="last_model_1.pt")}
+    trainer.checkpointers.clear()
+    trainer.checkpointers["checkpoint_last"] = mock.MagicMock(last_checkpoint="last_model_1.pt")
 
     with mock.patch("pathlib.Path.exists", return_value=True):
         from ignite.handlers.checkpoint import CheckpointEvents

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -18,7 +18,6 @@ from trainite.config import (
 )
 from trainite.datasets.string_reverse import DatapointModel
 from trainite.trainers.decoder_trainer import Trainer, TrainerConfig, ProjectConfig
-from trainite.shared.utils import upload_model_to_wandb
 from ignite.engine import Events
 from ignite.handlers import EarlyStopping
 import ignite.distributed as idist
@@ -383,37 +382,56 @@ def test_decoder_trainer_test_no_loader(project_config):
     mock_warning.assert_called_with("No test loader provided. Skipping testing.")
 
 
-def test_upload_model_to_wandb(project_config, temp_run_dir):
+@mock.patch("trainite.trainers.decoder_trainer.setup_experiment_tracking")
+def test_upload_model_to_wandb(mock_setup, project_config, temp_run_dir):
+    project_config.logger = "wandb"
+    mock_logger = mock.MagicMock()
+    mock_setup.return_value = mock_logger
+
     trainer = create_trainer_from_config(project_config)
-    trainer.exp_logger = mock.MagicMock()
     trainer.checkpointers = {"checkpoint_best": mock.MagicMock(last_checkpoint="best_model_1.pt")}
 
-    upload_model_to_wandb(
-        trainer.exp_logger,
-        trainer.checkpointers,
-        trainer.config.output.run_name,
-        trainer.logger,
-    )
+    with mock.patch("pathlib.Path.exists", return_value=True):
+        from ignite.handlers.checkpoint import CheckpointEvents
 
-    trainer.exp_logger.Artifact.return_value.add_file.assert_called_once_with("best_model_1.pt")
-    trainer.exp_logger.log_artifact.assert_called_once_with(trainer.exp_logger.Artifact.return_value)
+        trainer.val_evaluator.fire_event(CheckpointEvents.SAVED_CHECKPOINT)
+
+    mock_logger.Artifact.return_value.add_file.assert_called_once_with("best_model_1.pt")
+    mock_logger.log_artifact.assert_called_once_with(mock_logger.Artifact.return_value)
 
 
-def test_upload_model_to_wandb_no_checkpoint(project_config):
+@mock.patch("trainite.trainers.decoder_trainer.setup_experiment_tracking")
+def test_upload_model_to_wandb_no_checkpoint(mock_setup, project_config):
+    project_config.logger = "wandb"
+    mock_logger = mock.MagicMock()
+    mock_setup.return_value = mock_logger
+
     trainer = create_trainer_from_config(project_config)
-    trainer.exp_logger = mock.MagicMock()
-    trainer.checkpointers = {}  # nothing saved -> skip, don't crash
+    trainer.checkpointers = {}  # nothing saved
 
-    with mock.patch.object(trainer.logger, "warning") as mock_warning:
-        upload_model_to_wandb(
-            trainer.exp_logger,
-            trainer.checkpointers,
-            trainer.config.output.run_name,
-            trainer.logger,
-        )
+    from ignite.handlers.checkpoint import CheckpointEvents
 
-    trainer.exp_logger.log_artifact.assert_not_called()
-    mock_warning.assert_called_once()
+    trainer.val_evaluator.fire_event(CheckpointEvents.SAVED_CHECKPOINT)
+
+    mock_logger.log_artifact.assert_not_called()
+
+
+@mock.patch("trainite.trainers.decoder_trainer.setup_experiment_tracking")
+def test_upload_last_checkpoint_to_wandb(mock_setup, project_config, temp_run_dir):
+    project_config.logger = "wandb"
+    mock_logger = mock.MagicMock()
+    mock_setup.return_value = mock_logger
+
+    trainer = create_trainer_from_config(project_config)
+    trainer.checkpointers = {"checkpoint_last": mock.MagicMock(last_checkpoint="last_model_1.pt")}
+
+    with mock.patch("pathlib.Path.exists", return_value=True):
+        from ignite.handlers.checkpoint import CheckpointEvents
+
+        trainer.engine.fire_event(CheckpointEvents.SAVED_CHECKPOINT)
+
+    mock_logger.Artifact.return_value.add_file.assert_called_once_with("last_model_1.pt")
+    mock_logger.log_artifact.assert_called_once_with(mock_logger.Artifact.return_value)
 
 
 def test_decoder_trainer_test_method(project_config, temp_run_dir):

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -14,6 +14,7 @@ from ignite.handlers import (
     EarlyStopping,
     create_lr_scheduler_with_warmup,
 )
+from ignite.handlers.checkpoint import CheckpointEvents
 from ignite.handlers.fbresearch_logger import FBResearchLogger
 from ignite.handlers.param_scheduler import ParamScheduler
 from ignite.handlers.tensorboard_logger import TensorboardLogger
@@ -372,3 +373,38 @@ def setup_console_logger(
         output_transform=lambda output: {"loss": output["loss"].item()},
     )
     return logger
+
+
+def setup_wandb_checkpoint_uploads(
+    trainer: Engine,
+    val_evaluator: Engine,
+    checkpointers: dict[str, Any],
+    exp_logger: Any,
+    run_name: str,
+    logger: logging.Logger,
+) -> None:
+    """Register events and upload handlers to automatically log checkpoints to W&B in real-time."""
+
+    val_evaluator.register_events(*CheckpointEvents)
+    trainer.register_events(*CheckpointEvents)
+
+    def upload_best_model_artifact(engine):
+        best_checkpoint = checkpointers.get("checkpoint_best")
+        checkpoint_path = best_checkpoint.last_checkpoint if best_checkpoint else None
+        if checkpoint_path and Path(checkpoint_path).exists():
+            logger.info(f"Uploading new best model artifact to W&B: {checkpoint_path}")
+            artifact = exp_logger.Artifact(name=f"{run_name}-model".replace("/", "-"), type="model")
+            artifact.add_file(str(checkpoint_path))
+            exp_logger.log_artifact(artifact)
+
+    def upload_last_checkpoint_artifact(engine):
+        last_checkpoint = checkpointers.get("checkpoint_last")
+        checkpoint_path = last_checkpoint.last_checkpoint if last_checkpoint else None
+        if checkpoint_path and Path(checkpoint_path).exists():
+            logger.info(f"Uploading last checkpoint artifact to W&B: {checkpoint_path}")
+            artifact = exp_logger.Artifact(name=f"{run_name}-checkpoint".replace("/", "-"), type="checkpoint")
+            artifact.add_file(str(checkpoint_path))
+            exp_logger.log_artifact(artifact)
+
+    val_evaluator.add_event_handler(CheckpointEvents.SAVED_CHECKPOINT, upload_best_model_artifact)
+    trainer.add_event_handler(CheckpointEvents.SAVED_CHECKPOINT, upload_last_checkpoint_artifact)

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -357,23 +357,6 @@ def setup_experiment_tracking(
     return exp_logger
 
 
-def upload_model_to_wandb(
-    exp_logger: Any,
-    checkpointers: dict[str, Checkpoint],
-    run_name: str,
-    logger: logging.Logger,
-) -> None:
-    checkpoint = checkpointers.get("checkpoint_best")
-    checkpoint_path = checkpoint.last_checkpoint if checkpoint else None
-    if not checkpoint_path:
-        logger.warning("No checkpoint found; skipping model upload to Weights & Biases.")
-        return
-    artifact = exp_logger.Artifact(name=f"{run_name}-model".replace("/", "-"), type="model")
-    artifact.add_file(str(checkpoint_path))
-    exp_logger.log_artifact(artifact)
-    logger.info("Uploaded model checkpoint to Weights & Biases: %s", checkpoint_path)
-
-
 def setup_console_logger(
     run_dir: Path,
     engine: Engine,

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -255,14 +255,28 @@ def attach_early_stopping(
     return None
 
 
-def setup_checkpointing(
+def setup_training_checkpointing(
+    engine: Engine,
+    to_save: dict[str, Any],
+    run_dir: Path,
+) -> Checkpoint:
+    last_checkpoint = Checkpoint(
+        to_save=to_save,
+        save_handler=DiskSaver(dirname=str(run_dir), require_empty=False),
+        filename_prefix="last",
+        n_saved=1,
+        global_step_transform=lambda *_: engine.state.iteration,
+    )
+    engine.add_event_handler(Events.EPOCH_COMPLETED, last_checkpoint)
+    return last_checkpoint
+
+
+def setup_best_model_checkpoint(
     engine: Engine,
     val_evaluator: Engine,
     to_save: dict[str, Any],
     run_dir: Path,
-) -> dict[str, Checkpoint]:
-    checkpointers = {}
-
+) -> Checkpoint:
     def score_function(engine_val):
         loss = engine_val.state.metrics["loss"]
         return -loss
@@ -277,19 +291,7 @@ def setup_checkpointing(
         global_step_transform=lambda *_: engine.state.iteration,
     )
     val_evaluator.add_event_handler(Events.COMPLETED, checkpoint)
-    checkpointers["checkpoint_best"] = checkpoint
-
-    last_checkpoint = Checkpoint(
-        to_save=to_save,
-        save_handler=DiskSaver(dirname=str(run_dir), require_empty=False),
-        filename_prefix="last",
-        n_saved=1,
-        global_step_transform=lambda *_: engine.state.iteration,
-    )
-    engine.add_event_handler(Events.EPOCH_COMPLETED, last_checkpoint)
-
-    checkpointers["checkpoint_last"] = last_checkpoint
-    return checkpointers
+    return checkpoint
 
 
 def setup_experiment_logger(

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -272,7 +272,7 @@ def setup_best_model_checkpoint(
     val_evaluator: Engine,
     to_save: dict[str, Any],
     run_dir: Path,
-    score_function: Callable[[Engine], float],
+    score_function: Callable,
     score_name: str,
 ) -> Checkpoint:
     checkpoint = Checkpoint(

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -272,18 +272,9 @@ def setup_best_model_checkpoint(
     val_evaluator: Engine,
     to_save: dict[str, Any],
     run_dir: Path,
-    score_function: Callable[[Engine], float] | None = None,
-    score_name: str | None = None,
+    score_function: Callable[[Engine], float],
+    score_name: str,
 ) -> Checkpoint:
-    if score_function is None:
-
-        def score_function(engine_val):
-            loss = engine_val.state.metrics["loss"]
-            return -loss
-
-    if score_name is None:
-        score_name = "val_loss"
-
     checkpoint = Checkpoint(
         to_save=to_save,
         save_handler=DiskSaver(dirname=str(run_dir), require_empty=False),

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -384,27 +384,22 @@ def setup_wandb_checkpoint_uploads(
     logger: logging.Logger,
 ) -> None:
     """Register events and upload handlers to automatically log checkpoints to W&B in real-time."""
-
     val_evaluator.register_events(*CheckpointEvents)
     trainer.register_events(*CheckpointEvents)
 
     def upload_best_model_artifact(engine):
-        best_checkpoint = checkpointers.get("checkpoint_best")
-        checkpoint_path = best_checkpoint.last_checkpoint if best_checkpoint else None
-        if checkpoint_path and Path(checkpoint_path).exists():
-            logger.info(f"Uploading new best model artifact to W&B: {checkpoint_path}")
-            artifact = exp_logger.Artifact(name=f"{run_name}-model".replace("/", "-"), type="model")
-            artifact.add_file(str(checkpoint_path))
-            exp_logger.log_artifact(artifact)
+        checkpoint_path = checkpointers["checkpoint_best"].last_checkpoint
+        logger.info(f"Uploading new best model artifact to W&B: {checkpoint_path}")
+        artifact = exp_logger.Artifact(name=f"{run_name}-model".replace("/", "-"), type="model")
+        artifact.add_file(str(checkpoint_path))
+        exp_logger.log_artifact(artifact)
 
     def upload_last_checkpoint_artifact(engine):
-        last_checkpoint = checkpointers.get("checkpoint_last")
-        checkpoint_path = last_checkpoint.last_checkpoint if last_checkpoint else None
-        if checkpoint_path and Path(checkpoint_path).exists():
-            logger.info(f"Uploading last checkpoint artifact to W&B: {checkpoint_path}")
-            artifact = exp_logger.Artifact(name=f"{run_name}-checkpoint".replace("/", "-"), type="checkpoint")
-            artifact.add_file(str(checkpoint_path))
-            exp_logger.log_artifact(artifact)
+        checkpoint_path = checkpointers["checkpoint_last"].last_checkpoint
+        logger.info(f"Uploading last checkpoint artifact to W&B: {checkpoint_path}")
+        artifact = exp_logger.Artifact(name=f"{run_name}-checkpoint".replace("/", "-"), type="checkpoint")
+        artifact.add_file(str(checkpoint_path))
+        exp_logger.log_artifact(artifact)
 
     val_evaluator.add_event_handler(CheckpointEvents.SAVED_CHECKPOINT, upload_best_model_artifact)
     trainer.add_event_handler(CheckpointEvents.SAVED_CHECKPOINT, upload_last_checkpoint_artifact)

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -1,9 +1,11 @@
 import logging
+from pathlib import Path
 from typing import Any, Literal
 
 import ignite.distributed as idist
 import torch
 from ignite.engine import Engine, Events
+from ignite.handlers.checkpoint import CheckpointEvents
 from ignite.metrics import Accuracy, Loss, Metric, RunningAverage
 from ignite.utils import setup_logger
 from pydantic import BaseModel, ConfigDict, Field
@@ -30,9 +32,8 @@ from trainite.shared.utils import (
     make_run_dir,
     setup_best_model_checkpoint,
     setup_console_logger,
-    setup_training_checkpointing,
     setup_experiment_tracking,
-    upload_model_to_wandb,
+    setup_training_checkpointing,
 )
 
 
@@ -147,6 +148,36 @@ class Trainer:
             bool(self.test_loader),
             config.output.run_name,
         )
+
+        if config.logger == "wandb":
+            self.val_evaluator.register_events(*CheckpointEvents)
+            self.engine.register_events(*CheckpointEvents)
+
+            # 1. Upload best model artifact immediately when a better one is saved
+            @self.val_evaluator.on(CheckpointEvents.SAVED_CHECKPOINT)
+            def upload_best_model_artifact(engine):
+                best_checkpoint = self.checkpointers.get("checkpoint_best")
+                checkpoint_path = best_checkpoint.last_checkpoint if best_checkpoint else None
+                if checkpoint_path and Path(checkpoint_path).exists():
+                    self.logger.info(f"Uploading new best model artifact to W&B: {checkpoint_path}")
+                    artifact = self.exp_logger.Artifact(
+                        name=f"{config.output.run_name}-model".replace("/", "-"), type="model"
+                    )
+                    artifact.add_file(str(checkpoint_path))
+                    self.exp_logger.log_artifact(artifact)
+
+            # 2. Upload last epoch checkpoint artifact immediately when saved
+            @self.engine.on(CheckpointEvents.SAVED_CHECKPOINT)
+            def upload_last_checkpoint_artifact(engine):
+                last_checkpoint = self.checkpointers.get("checkpoint_last")
+                checkpoint_path = last_checkpoint.last_checkpoint if last_checkpoint else None
+                if checkpoint_path and Path(checkpoint_path).exists():
+                    self.logger.info(f"Uploading last checkpoint artifact to W&B: {checkpoint_path}")
+                    artifact = self.exp_logger.Artifact(
+                        name=f"{config.output.run_name}-checkpoint".replace("/", "-"), type="checkpoint"
+                    )
+                    artifact.add_file(str(checkpoint_path))
+                    self.exp_logger.log_artifact(artifact)
 
         # Run evaluations at the end of each epoch to log training and validation metrics
         self.engine.add_event_handler(Events.EPOCH_COMPLETED, self._run_evaluations)
@@ -438,13 +469,5 @@ class Trainer:
 
         if self.test_loader:
             self.test()
-
-        if self.config.logger == "wandb":
-            upload_model_to_wandb(
-                self.exp_logger,
-                self.checkpointers,
-                self.config.output.run_name,
-                self.logger,
-            )
 
         self.exp_logger.close()

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -112,21 +112,20 @@ class Trainer:
             return -loss
 
         # Attach checkpointing
-        self.checkpointers = {
-            "checkpoint_best": setup_best_model_checkpoint(
-                self.trainer,
-                self.val_evaluator,
-                {"model": self.model, "optimizer": self.optimizer},
-                self.run_dir,
-                score_function=score_function,
-                score_name="val_loss",
-            ),
-            "checkpoint_last": setup_training_checkpointing(
-                self.trainer,
-                {"model": self.model, "optimizer": self.optimizer},
-                self.run_dir,
-            ),
-        }
+        self.checkpointers = {}
+        self.checkpointers["checkpoint_best"] = setup_best_model_checkpoint(
+            self.trainer,
+            self.val_evaluator,
+            {"model": self.model, "optimizer": self.optimizer},
+            self.run_dir,
+            score_function=score_function,
+            score_name="val_loss",
+        )
+        self.checkpointers["checkpoint_last"] = setup_training_checkpointing(
+            self.trainer,
+            {"model": self.model, "optimizer": self.optimizer},
+            self.run_dir,
+        )
 
         # Attach experiment logger (TensorBoard or Weights & Biases)
         self.exp_logger = setup_experiment_tracking(
@@ -259,8 +258,6 @@ class Trainer:
         self.val_evaluator.register_events(*CheckpointEvents)
         self.trainer.register_events(*CheckpointEvents)
 
-        # 1. Upload best model artifact immediately when a better one is saved
-        @self.val_evaluator.on(CheckpointEvents.SAVED_CHECKPOINT)
         def upload_best_model_artifact(engine):
             best_checkpoint = self.checkpointers.get("checkpoint_best")
             checkpoint_path = best_checkpoint.last_checkpoint if best_checkpoint else None
@@ -272,8 +269,6 @@ class Trainer:
                 artifact.add_file(str(checkpoint_path))
                 self.exp_logger.log_artifact(artifact)
 
-        # 2. Upload last epoch checkpoint artifact immediately when saved
-        @self.trainer.on(CheckpointEvents.SAVED_CHECKPOINT)
         def upload_last_checkpoint_artifact(engine):
             last_checkpoint = self.checkpointers.get("checkpoint_last")
             checkpoint_path = last_checkpoint.last_checkpoint if last_checkpoint else None
@@ -284,6 +279,9 @@ class Trainer:
                 )
                 artifact.add_file(str(checkpoint_path))
                 self.exp_logger.log_artifact(artifact)
+
+        self.val_evaluator.add_event_handler(CheckpointEvents.SAVED_CHECKPOINT, upload_best_model_artifact)
+        self.trainer.add_event_handler(CheckpointEvents.SAVED_CHECKPOINT, upload_last_checkpoint_artifact)
 
     def _log_inference(self, engine: Engine, loader: DataLoader, name: str) -> None:
         self.logger.info(f"Epoch {engine.state.epoch}: Running inference on {name} samples...")

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -28,9 +28,10 @@ from trainite.shared.utils import (
     dump_config,
     instantiate,
     make_run_dir,
-    setup_checkpointing,
+    setup_best_model_checkpoint,
     setup_console_logger,
     setup_experiment_logger,
+    setup_training_checkpointing,
     upload_model_to_wandb,
 )
 
@@ -119,12 +120,19 @@ class Trainer:
         attach_early_stopping(self.val_evaluator, self.engine, config.trainer.early_stopping_patience)
 
         # Attach checkpointing
-        self.checkpointers = setup_checkpointing(
-            self.engine,
-            self.val_evaluator,
-            {"model": self.model, "optimizer": self.optimizer},
-            self.run_dir,
-        )
+        self.checkpointers = {
+            "checkpoint_best": setup_best_model_checkpoint(
+                self.engine,
+                self.val_evaluator,
+                {"model": self.model, "optimizer": self.optimizer},
+                self.run_dir,
+            ),
+            "checkpoint_last": setup_training_checkpointing(
+                self.engine,
+                {"model": self.model, "optimizer": self.optimizer},
+                self.run_dir,
+            ),
+        }
 
         # Attach experiment logger (TensorBoard or Weights & Biases)
         self.exp_logger = setup_experiment_logger(

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -106,6 +106,11 @@ class Trainer:
         # Attach early stopping
         attach_early_stopping(self.val_evaluator, self.trainer, self.trainer_config.early_stopping_patience)
 
+        # Define validation scoring function for best model
+        def score_function(engine_val):
+            loss = engine_val.state.metrics["loss"]
+            return -loss
+
         # Attach checkpointing
         self.checkpointers = {
             "checkpoint_best": setup_best_model_checkpoint(
@@ -113,6 +118,8 @@ class Trainer:
                 self.val_evaluator,
                 {"model": self.model, "optimizer": self.optimizer},
                 self.run_dir,
+                score_function=score_function,
+                score_name="val_loss",
             ),
             "checkpoint_last": setup_training_checkpointing(
                 self.trainer,
@@ -135,35 +142,9 @@ class Trainer:
             config.output.run_name,
         )
 
+        # Real-time W&B uploads
         if config.logger == "wandb":
-            self.val_evaluator.register_events(*CheckpointEvents)
-            self.trainer.register_events(*CheckpointEvents)
-
-            # 1. Upload best model artifact immediately when a better one is saved
-            @self.val_evaluator.on(CheckpointEvents.SAVED_CHECKPOINT)
-            def upload_best_model_artifact(engine):
-                best_checkpoint = self.checkpointers.get("checkpoint_best")
-                checkpoint_path = best_checkpoint.last_checkpoint if best_checkpoint else None
-                if checkpoint_path and Path(checkpoint_path).exists():
-                    self.logger.info(f"Uploading new best model artifact to W&B: {checkpoint_path}")
-                    artifact = self.exp_logger.Artifact(
-                        name=f"{config.output.run_name}-model".replace("/", "-"), type="model"
-                    )
-                    artifact.add_file(str(checkpoint_path))
-                    self.exp_logger.log_artifact(artifact)
-
-            # 2. Upload last epoch checkpoint artifact immediately when saved
-            @self.trainer.on(CheckpointEvents.SAVED_CHECKPOINT)
-            def upload_last_checkpoint_artifact(engine):
-                last_checkpoint = self.checkpointers.get("checkpoint_last")
-                checkpoint_path = last_checkpoint.last_checkpoint if last_checkpoint else None
-                if checkpoint_path and Path(checkpoint_path).exists():
-                    self.logger.info(f"Uploading last checkpoint artifact to W&B: {checkpoint_path}")
-                    artifact = self.exp_logger.Artifact(
-                        name=f"{config.output.run_name}-checkpoint".replace("/", "-"), type="checkpoint"
-                    )
-                    artifact.add_file(str(checkpoint_path))
-                    self.exp_logger.log_artifact(artifact)
+            self._setup_wandb_checkpoint_uploads()
 
         # Run evaluations at the end of each epoch to log training and validation metrics
         self.trainer.add_event_handler(Events.EPOCH_COMPLETED, self._run_evaluations)
@@ -272,6 +253,37 @@ class Trainer:
             val_metrics["loss"],
             val_metrics["token_accuracy"],
         )
+
+    def _setup_wandb_checkpoint_uploads(self) -> None:
+        """Register events and upload handlers to automatically log checkpoints to W&B in real-time."""
+        self.val_evaluator.register_events(*CheckpointEvents)
+        self.trainer.register_events(*CheckpointEvents)
+
+        # 1. Upload best model artifact immediately when a better one is saved
+        @self.val_evaluator.on(CheckpointEvents.SAVED_CHECKPOINT)
+        def upload_best_model_artifact(engine):
+            best_checkpoint = self.checkpointers.get("checkpoint_best")
+            checkpoint_path = best_checkpoint.last_checkpoint if best_checkpoint else None
+            if checkpoint_path and Path(checkpoint_path).exists():
+                self.logger.info(f"Uploading new best model artifact to W&B: {checkpoint_path}")
+                artifact = self.exp_logger.Artifact(
+                    name=f"{self.config.output.run_name}-model".replace("/", "-"), type="model"
+                )
+                artifact.add_file(str(checkpoint_path))
+                self.exp_logger.log_artifact(artifact)
+
+        # 2. Upload last epoch checkpoint artifact immediately when saved
+        @self.trainer.on(CheckpointEvents.SAVED_CHECKPOINT)
+        def upload_last_checkpoint_artifact(engine):
+            last_checkpoint = self.checkpointers.get("checkpoint_last")
+            checkpoint_path = last_checkpoint.last_checkpoint if last_checkpoint else None
+            if checkpoint_path and Path(checkpoint_path).exists():
+                self.logger.info(f"Uploading last checkpoint artifact to W&B: {checkpoint_path}")
+                artifact = self.exp_logger.Artifact(
+                    name=f"{self.config.output.run_name}-checkpoint".replace("/", "-"), type="checkpoint"
+                )
+                artifact.add_file(str(checkpoint_path))
+                self.exp_logger.log_artifact(artifact)
 
     def _log_inference(self, engine: Engine, loader: DataLoader, name: str) -> None:
         self.logger.info(f"Epoch {engine.state.epoch}: Running inference on {name} samples...")

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -1,12 +1,10 @@
 import itertools
 import logging
-from pathlib import Path
 from typing import Literal
 
 import ignite.distributed as idist
 import torch
 from ignite.engine import Engine, Events
-from ignite.handlers.checkpoint import CheckpointEvents
 from ignite.metrics import Accuracy, Loss, Metric, RunningAverage
 from ignite.utils import setup_logger
 from pydantic import BaseModel, ConfigDict, Field
@@ -35,6 +33,7 @@ from trainite.shared.utils import (
     setup_console_logger,
     setup_experiment_tracking,
     setup_training_checkpointing,
+    setup_wandb_checkpoint_uploads,
 )
 
 
@@ -143,7 +142,14 @@ class Trainer:
 
         # Real-time W&B uploads
         if config.logger == "wandb":
-            self._setup_wandb_checkpoint_uploads()
+            setup_wandb_checkpoint_uploads(
+                self.trainer,
+                self.val_evaluator,
+                self.checkpointers,
+                self.exp_logger,
+                config.output.run_name,
+                self.logger,
+            )
 
         # Run evaluations at the end of each epoch to log training and validation metrics
         self.trainer.add_event_handler(Events.EPOCH_COMPLETED, self._run_evaluations)
@@ -252,36 +258,6 @@ class Trainer:
             val_metrics["loss"],
             val_metrics["token_accuracy"],
         )
-
-    def _setup_wandb_checkpoint_uploads(self) -> None:
-        """Register events and upload handlers to automatically log checkpoints to W&B in real-time."""
-        self.val_evaluator.register_events(*CheckpointEvents)
-        self.trainer.register_events(*CheckpointEvents)
-
-        def upload_best_model_artifact(engine):
-            best_checkpoint = self.checkpointers.get("checkpoint_best")
-            checkpoint_path = best_checkpoint.last_checkpoint if best_checkpoint else None
-            if checkpoint_path and Path(checkpoint_path).exists():
-                self.logger.info(f"Uploading new best model artifact to W&B: {checkpoint_path}")
-                artifact = self.exp_logger.Artifact(
-                    name=f"{self.config.output.run_name}-model".replace("/", "-"), type="model"
-                )
-                artifact.add_file(str(checkpoint_path))
-                self.exp_logger.log_artifact(artifact)
-
-        def upload_last_checkpoint_artifact(engine):
-            last_checkpoint = self.checkpointers.get("checkpoint_last")
-            checkpoint_path = last_checkpoint.last_checkpoint if last_checkpoint else None
-            if checkpoint_path and Path(checkpoint_path).exists():
-                self.logger.info(f"Uploading last checkpoint artifact to W&B: {checkpoint_path}")
-                artifact = self.exp_logger.Artifact(
-                    name=f"{self.config.output.run_name}-checkpoint".replace("/", "-"), type="checkpoint"
-                )
-                artifact.add_file(str(checkpoint_path))
-                self.exp_logger.log_artifact(artifact)
-
-        self.val_evaluator.add_event_handler(CheckpointEvents.SAVED_CHECKPOINT, upload_best_model_artifact)
-        self.trainer.add_event_handler(CheckpointEvents.SAVED_CHECKPOINT, upload_last_checkpoint_artifact)
 
     def _log_inference(self, engine: Engine, loader: DataLoader, name: str) -> None:
         self.logger.info(f"Epoch {engine.state.epoch}: Running inference on {name} samples...")


### PR DESCRIPTION
## Description

### Overview
This pull request refactors the monolithic checkpoint setup function `setup_checkpointing` in `trainite/shared/utils.py` into two focused helper functions:
1. `setup_training_checkpointing` (for saving `last.pt` checkpoint on training epoch completion).
2. `setup_best_model_checkpoint` (for saving `best.pt` checkpoint on validation completion based on loss).