### PR TITLE
upload and copy config.yaml as YAML file for WandB and TensorBoard

### DIFF
--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -1,7 +1,6 @@
 import importlib
 import inspect
 import logging
-import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Literal, TypeVar
@@ -304,7 +303,7 @@ def setup_experiment_tracking(
     else:
         log_dir = run_dir / "tensorboard"
         log_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(run_dir / "config.yaml", log_dir / "config.yaml")
+        (log_dir / "config.yaml").write_bytes((run_dir / "config.yaml").read_bytes())
         exp_logger = TensorboardLogger(log_dir=log_dir)
 
     # Log training iteration loss

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import logging
+import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, TypeVar
@@ -306,8 +307,13 @@ def setup_experiment_tracking(
 ) -> TensorboardLogger | WandBLogger:
     if backend == "wandb":
         exp_logger = WandBLogger(project=run_name, dir=str(run_dir), name=str(run_dir).split("/")[-1])
+        if run_dir and (run_dir / "config.yaml").exists():
+            exp_logger.save(str(run_dir / "config.yaml"))
     else:
         log_dir = run_dir / "tensorboard" if run_dir else None
+        if log_dir and run_dir and (run_dir / "config.yaml").exists():
+            log_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(run_dir / "config.yaml", log_dir / "config.yaml")
         exp_logger = TensorboardLogger(log_dir=log_dir)
 
     # Log training iteration loss

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -296,14 +296,15 @@ def setup_experiment_tracking(
     metric_names: list[str],
     has_test: bool,
     run_name: str,
+    config: BaseModel
 ) -> TensorboardLogger | WandBLogger:
     if backend == "wandb":
         exp_logger = WandBLogger(project=run_name, dir=str(run_dir), name=str(run_dir).split("/")[-1])
         exp_logger.save(str(run_dir / "config.yaml"))
     else:
         log_dir = run_dir / "tensorboard"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        (log_dir / "config.yaml").write_bytes((run_dir / "config.yaml").read_bytes())
+        config_path = run_dir / "config.yaml"
+        dump_config(config, config_path)
         exp_logger = TensorboardLogger(log_dir=log_dir)
 
     # Log training iteration loss

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -296,7 +296,7 @@ def setup_experiment_tracking(
     metric_names: list[str],
     has_test: bool,
     run_name: str,
-    config: BaseModel
+    config: BaseModel,
 ) -> TensorboardLogger | WandBLogger:
     if backend == "wandb":
         exp_logger = WandBLogger(project=run_name, dir=str(run_dir), name=str(run_dir).split("/")[-1])

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -304,13 +304,11 @@ def setup_experiment_tracking(
 ) -> TensorboardLogger | WandBLogger:
     if backend == "wandb":
         exp_logger = WandBLogger(project=run_name, dir=str(run_dir), name=str(run_dir).split("/")[-1])
-        if run_dir and (run_dir / "config.yaml").exists():
-            exp_logger.save(str(run_dir / "config.yaml"))
+        exp_logger.save(str(run_dir / "config.yaml"))
     else:
-        log_dir = run_dir / "tensorboard" if run_dir else None
-        if log_dir and run_dir and (run_dir / "config.yaml").exists():
-            log_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(run_dir / "config.yaml", log_dir / "config.yaml")
+        log_dir = run_dir / "tensorboard"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(run_dir / "config.yaml", log_dir / "config.yaml")
         exp_logger = TensorboardLogger(log_dir=log_dir)
 
     # Log training iteration loss

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -149,6 +149,7 @@ class Trainer:
             ["loss", "token_accuracy"],
             bool(self.test_loader),
             config.output.run_name,
+            config,
         )
 
         # Real-time W&B uploads

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -423,9 +423,6 @@ class Trainer:
 
     def run(self) -> None:
         self.logger.info("starting run in %s", self.run_dir)
-        config_data = self.config.model_dump(by_alias=True, polymorphic_serialization=True)
-        self._log_text("config", str(config_data), 0)
-
         self.engine.run(self.train_loader, max_epochs=self.epochs)
 
         if self.test_loader:


### PR DESCRIPTION
## Description

### Overview
This pull request improves how the training configuration (`config.yaml`) is logged and stored during an experiment run:
1. **Weights & Biases (WandB)**: Uploads the physical `config.yaml` file to the run using the `exp_logger.save` method, allowing it to be viewed and downloaded under the **Files** tab of the W&B run dashboard.
2. **TensorBoard**: Copies the `config.yaml` file directly into the `tensorboard/` logging directory. This ensures the configuration is co-located with the binary event logs for easy archival and offline auditing.
3. **Cleaned up Inline Dictionary Logs**: Removed the previous behavior of stringifying the Pydantic config dictionary (`str(config_data)`) and logging it as a preformatted HTML/text block under the `"config"` key.