### PR TITLE
decouple-checkpointers

### DIFF
--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -336,7 +336,7 @@ def test_decoder_trainer_run_with_val(project_config, temp_run_dir):
 
     event_handlers = trainer.val_evaluator._event_handlers.get(Events.COMPLETED, [])
     assert any(isinstance(h[0], EarlyStopping) for h in event_handlers)
-    assert "checkpoint_best" in trainer.checkpointers
+    assert trainer.best_checkpoint is not None
 
 
 @pytest.mark.skip(reason="Skipping this test because validation is required.")
@@ -370,7 +370,7 @@ def test_decoder_trainer_run_without_val(project_config, temp_run_dir):
     # Early stopping and best checkpoint should NOT be in handlers / attached
     event_handlers = trainer.val_evaluator._event_handlers.get(Events.COMPLETED, [])
     assert not any(isinstance(h[0], EarlyStopping) for h in event_handlers)
-    assert "checkpoint_best" not in trainer.checkpointers
+    assert trainer.best_checkpoint is not None
 
 
 def test_decoder_trainer_test_no_loader(project_config):
@@ -392,8 +392,7 @@ def test_upload_model_to_wandb(mock_setup, project_config, temp_run_dir):
     mock_setup.return_value = mock_logger
 
     trainer = create_trainer_from_config(project_config)
-    trainer.checkpointers.clear()
-    trainer.checkpointers["checkpoint_best"] = mock.MagicMock(last_checkpoint="best_model_1.pt")
+    trainer.best_checkpoint = mock.MagicMock(last_checkpoint="best_model_1.pt")
 
     from ignite.handlers.checkpoint import CheckpointEvents
 
@@ -410,8 +409,7 @@ def test_upload_last_checkpoint_to_wandb(mock_setup, project_config, temp_run_di
     mock_setup.return_value = mock_logger
 
     trainer = create_trainer_from_config(project_config)
-    trainer.checkpointers.clear()
-    trainer.checkpointers["checkpoint_last"] = mock.MagicMock(last_checkpoint="last_model_1.pt")
+    trainer.last_checkpoint = mock.MagicMock(last_checkpoint="last_model_1.pt")
 
     from ignite.handlers.checkpoint import CheckpointEvents
 
@@ -468,14 +466,14 @@ def test_decoder_trainer_test_without_val(project_config, temp_run_dir):
     trainer.run()
 
     # checkpoint_best should not exist, it should use checkpoint_last
-    assert "checkpoint_best" not in trainer.checkpointers
-    assert "checkpoint_last" in trainer.checkpointers
+    assert trainer.best_checkpoint is not None
+    assert trainer.last_checkpoint is not None
 
     with mock.patch("torch.load", side_effect=torch.load) as mock_load:
         trainer.test()
 
     # Verify that it loaded the last checkpoint
-    last_checkpoint_path = trainer.checkpointers["checkpoint_last"].last_checkpoint
+    last_checkpoint_path = trainer.last_checkpoint.last_checkpoint
     mock_load.assert_any_call(last_checkpoint_path, map_location=trainer.device, weights_only=True)
 
 

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -471,7 +471,6 @@ def test_decoder_trainer_test_without_val(project_config, temp_run_dir):
     trainer = create_trainer_from_config(project_config)
     trainer.run()
 
-    # checkpoint_best should not exist, it should use checkpoint_last
     assert trainer.best_checkpoint is not None
     assert trainer.last_checkpoint is not None
 

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -386,13 +386,16 @@ def test_decoder_trainer_test_no_loader(project_config):
 
 
 @mock.patch("trainite.trainers.decoder_trainer.setup_experiment_tracking")
-def test_upload_model_to_wandb(mock_setup, project_config, temp_run_dir):
+@mock.patch("trainite.trainers.decoder_trainer.setup_best_model_checkpoint")
+def test_upload_model_to_wandb(mock_setup_best, mock_setup, project_config, temp_run_dir):
     project_config.logger = "wandb"
     mock_logger = mock.MagicMock()
     mock_setup.return_value = mock_logger
 
+    mock_best = mock.MagicMock(last_checkpoint="best_model_1.pt")
+    mock_setup_best.return_value = mock_best
+
     trainer = create_trainer_from_config(project_config)
-    trainer.best_checkpoint = mock.MagicMock(last_checkpoint="best_model_1.pt")
 
     from ignite.handlers.checkpoint import CheckpointEvents
 
@@ -403,13 +406,16 @@ def test_upload_model_to_wandb(mock_setup, project_config, temp_run_dir):
 
 
 @mock.patch("trainite.trainers.decoder_trainer.setup_experiment_tracking")
-def test_upload_last_checkpoint_to_wandb(mock_setup, project_config, temp_run_dir):
+@mock.patch("trainite.trainers.decoder_trainer.setup_training_checkpointing")
+def test_upload_last_checkpoint_to_wandb(mock_setup_last, mock_setup, project_config, temp_run_dir):
     project_config.logger = "wandb"
     mock_logger = mock.MagicMock()
     mock_setup.return_value = mock_logger
 
+    mock_last = mock.MagicMock(last_checkpoint="last_model_1.pt")
+    mock_setup_last.return_value = mock_last
+
     trainer = create_trainer_from_config(project_config)
-    trainer.last_checkpoint = mock.MagicMock(last_checkpoint="last_model_1.pt")
 
     from ignite.handlers.checkpoint import CheckpointEvents
 

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -375,7 +375,8 @@ def setup_console_logger(
 def setup_wandb_checkpoint_uploads(
     trainer: Engine,
     val_evaluator: Engine,
-    checkpointers: dict[str, Any],
+    best_checkpoint: Checkpoint,
+    last_checkpoint: Checkpoint,
     exp_logger: Any,
     run_name: str,
     logger: logging.Logger,
@@ -385,14 +386,14 @@ def setup_wandb_checkpoint_uploads(
     trainer.register_events(*CheckpointEvents)
 
     def upload_best_model_artifact(engine):
-        checkpoint_path = checkpointers["checkpoint_best"].last_checkpoint
+        checkpoint_path = best_checkpoint.last_checkpoint
         logger.info(f"Uploading new best model artifact to W&B: {checkpoint_path}")
         artifact = exp_logger.Artifact(name=f"{run_name}-model".replace("/", "-"), type="model")
         artifact.add_file(str(checkpoint_path))
         exp_logger.log_artifact(artifact)
 
     def upload_last_checkpoint_artifact(engine):
-        checkpoint_path = checkpointers["checkpoint_last"].last_checkpoint
+        checkpoint_path = last_checkpoint.last_checkpoint
         logger.info(f"Uploading last checkpoint artifact to W&B: {checkpoint_path}")
         artifact = exp_logger.Artifact(name=f"{run_name}-checkpoint".replace("/", "-"), type="checkpoint")
         artifact.add_file(str(checkpoint_path))

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -90,8 +90,7 @@ class Trainer:
             return -loss
 
         # Attach checkpointing
-        self.checkpointers = {}
-        self.checkpointers["checkpoint_best"] = setup_best_model_checkpoint(
+        self.best_checkpoint = setup_best_model_checkpoint(
             self.trainer,
             self.val_evaluator,
             {"model": self.model, "optimizer": self.optimizer},
@@ -99,7 +98,7 @@ class Trainer:
             score_function=score_function,
             score_name="val_loss",
         )
-        self.checkpointers["checkpoint_last"] = setup_training_checkpointing(
+        self.last_checkpoint = setup_training_checkpointing(
             self.trainer,
             {"model": self.model, "optimizer": self.optimizer},
             self.run_dir,
@@ -124,7 +123,8 @@ class Trainer:
             setup_wandb_checkpoint_uploads(
                 self.trainer,
                 self.val_evaluator,
-                self.checkpointers,
+                self.best_checkpoint,
+                self.last_checkpoint,
                 self.exp_logger,
                 config.output.run_name,
                 self.logger,
@@ -202,7 +202,7 @@ class Trainer:
             return
 
         # Load best model if available
-        checkpoint_handler = self.checkpointers.get("checkpoint_best", None)
+        checkpoint_handler = self.best_checkpoint
         if checkpoint_handler and checkpoint_handler.last_checkpoint:
             checkpoint_path = checkpoint_handler.last_checkpoint
 


### PR DESCRIPTION
This pull request refactors how checkpoint handlers are stored and passed around in the decoder trainer and utility functions. Instead of using a dictionary to manage checkpoint handlers, it now uses explicit attributes for the best and last checkpoints, which simplifies the code and improves clarity. The changes also update related function signatures and usages accordingly.

Refactoring checkpoint handler management:

* Replaced the `checkpointers` dictionary with explicit `best_checkpoint` and `last_checkpoint` attributes in the `DecoderTrainer` class, updating all usages to reference these attributes directly instead of dictionary keys. [[1]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL93-R101) [[2]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL205-R205)
* Updated the `setup_wandb_checkpoint_uploads` function signature to accept `best_checkpoint` and `last_checkpoint` directly, and refactored its internal logic to use these parameters instead of dictionary lookups. [[1]](diffhunk://#diff-95664947e337a24cae1f3e4435b2f7c9583235285155de1ca6447fa7b50257bdL378-R379) [[2]](diffhunk://#diff-95664947e337a24cae1f3e4435b2f7c9583235285155de1ca6447fa7b50257bdL388-R396) [[3]](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL127-R127