### PR TITLE
simplifed train evaluation

### DIFF
--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 
 import ignite.distributed as idist
@@ -169,8 +168,7 @@ class Trainer:
 
     def _run_evaluations(self, engine: Engine) -> None:
         self.logger.info("Evaluating on training set...")
-        eval_loader = itertools.islice(self.train_loader, len(self.val_loader))
-        self.train_evaluator.run(eval_loader)
+        self.train_evaluator.run(self.train_loader, epoch_length=min(len(self.train_loader), len(self.val_loader)))
         train_metrics = self.train_evaluator.state.metrics
         epoch = engine.state.epoch
 


### PR DESCRIPTION
This pull request makes a minor update to the evaluation logic in the `DecoderTrainer` class to simplify the way the training set is evaluated during the evaluation phase.

- Simplified training set evaluation:
  * [`trainite/trainers/decoder_trainer.py`](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL172-R171): Replaced the use of `itertools.islice` to limit the training loader with the `epoch_length` argument in `self.train_evaluator.run`, ensuring evaluation uses the correct number of batches.
  * [`trainite/trainers/decoder_trainer.py`](diffhunk://#diff-fac8db1e50d0671d7f20e3686be7e2b854d30ae6906a3f8b919154c5b760b20dL1): Removed the unused `itertools` import since it is no longer needed.