### PR TITLE
Document `utils.py` and ensure experiment logger is closed on exception

### DIFF
--- a/trainite/templates/project/README.md
+++ b/trainite/templates/project/README.md
@@ -93,6 +93,12 @@ If you prefer standard Python tools, you can create a virtual environment and us
 ### Preprocessor: {{preprocessor_name}}
 {{preprocessor_docs}}
 
+## Understanding `utils.py`
+
+`utils.py` contains the bootstrapping and setup logic that links your configurations to executable code. It primarily acts as the file where all the helper functions are located that are being used in `trainer.py`. It handles parsing of dynamic `_target_` paths from `config.yaml`, builds your models and datasets, manages dataset splitting, and attaches standard PyTorch-Ignite event handlers (such as checkpointing, early stopping, learning rate scheduling, and logging).
+
+Since the generated code in `utils.py` belongs to you, you can modify it directly to customize checkpoint rules, adjust early stopping metrics, or add new loggers.
+
 ## Customization
 
 ### Dataset Configuration

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -181,12 +181,13 @@ class Trainer:
 
     def run(self) -> None:
         self.logger.info("starting run in %s", self.run_dir)
-        self.trainer.run(self.train_loader, max_epochs=self.epochs)
+        try:
+            self.trainer.run(self.train_loader, max_epochs=self.epochs)
 
-        if self.test_loader:
-            self.test()
-
-        self.exp_logger.close()
+            if self.test_loader:
+                self.test()
+        finally:
+            self.exp_logger.close()
 
     def test(self, test_loader: DataLoader | None = None) -> None:
         loader = test_loader or self.test_loader


### PR DESCRIPTION
## Description

This PR introduces two improvements to the codebase:
1. **Document `utils.py` in the Generated Project Template**:
   Adds a dedicated `## Understanding utils.py` section in the project template's `README.md` right after the tokenizer/preprocessor component subsection. It clarifies the role of `utils.py` as the home for helper functions used in `trainer.py` and explains its responsibilities (late-binding target instantiation via `_target_`, dataset builders, and PyTorch-Ignite handler attachment).
2. **Robust Logger Closure**:
   Wraps the training and testing loop inside `Trainer.run()` in a `try...finally` block within `trainite/trainers/decoder_trainer.py`. This guarantees `self.exp_logger.close()` is always executed on completion, error, or user interrupt (such as `KeyboardInterrupt`), ensuring log files and telemetry configurations (like TensorBoard or ClearML) are cleanly closed and flushed.