### PR TITLE
simplify collate_fn and registery

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from trainite.config.registry import get_dataset_spec, get_model_spec, get_preprocessor_spec, get_trainer_spec
+from trainite.config.registry import MODEL_SPECS, DATASET_SPECS, PREPROCESSOR_SPECS, TRAINER_SPECS
 
 
 @pytest.mark.parametrize(
@@ -34,11 +34,11 @@ def test_init_generates_valid_project(model: str, dataset: str, trainer: str) ->
         ]
         subprocess.run(cmd, check=True, timeout=60)
 
-        dataset_spec = get_dataset_spec(dataset)
-        model_spec = get_model_spec(model)
-        trainer_spec = get_trainer_spec(trainer)
+        dataset_spec = DATASET_SPECS[dataset]
+        model_spec = MODEL_SPECS[model]
+        trainer_spec = TRAINER_SPECS[trainer]
         preprocessor_spec = (
-            get_preprocessor_spec(dataset_spec.preprocessor_spec_name) if dataset_spec.preprocessor_spec_name else None
+            PREPROCESSOR_SPECS[dataset_spec.preprocessor_spec_name] if dataset_spec.preprocessor_spec_name else None
         )
         preprocessor_file = f"preprocessors/{preprocessor_spec.name}.py" if preprocessor_spec else None
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+import yaml
 
 import pytest
 
@@ -59,6 +60,12 @@ def test_init_generates_valid_project(model: str, dataset: str, trainer: str) ->
             if filename is not None:
                 assert (project_dir / filename).exists(), f"{filename} missing"
 
+        # Check that targets inside config.yaml are rewritten correctly
+        with open(project_dir / "config.yaml", "r") as f:
+            generated_config = yaml.safe_load(f)
+        assert generated_config["model"]["_target_"].startswith("models.")
+        assert generated_config["model"]["collate_fn_target"].startswith("models.")
+
         # Check if python files are parseable
         python_files = [
             "config.py",
@@ -102,7 +109,6 @@ def test_generated_string_reversal_project_is_runnable() -> None:
 
         # 2. Modify config.yaml to run for only 1 step/epoch to keep test fast
         config_path = project_dir / "config.yaml"
-        import yaml
 
         with open(config_path, "r") as f:
             config = yaml.safe_load(f)

--- a/tests/datasets/string_reverse_test.py
+++ b/tests/datasets/string_reverse_test.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from torch.utils.data import DataLoader
-from trainite.config.registry import get_dataset_spec
+from trainite.config.registry import DATASET_SPECS, MODEL_SPECS
 from trainite.datasets.string_reverse import (
     CHARSET_PRESETS,
     PromptCompletionTransform,
@@ -10,7 +10,6 @@ from trainite.datasets.string_reverse import (
 from trainite.datasets.transformed import TransformedDataset
 from trainite.preprocessors.char_tokenizer import CharTokenizer
 from trainite.shared.utils import build_dataset, get_target
-from trainite.config.registry import get_model_spec
 from trainite.config.datasets import StringReverseDatasetConfig, StringReverseDataConfig
 
 
@@ -100,13 +99,13 @@ def test_build_string_reverse_dataset():
 
 
 def test_config_build_string_reverse_dataset():
-    spec = get_dataset_spec("string-reverse")
+    spec = DATASET_SPECS["string-reverse"]
     dataset_conf = spec.config_cls()
     tokenizer = CharTokenizer()
     dataset = build_dataset(dataset_conf.dataset, dataset_conf.transform, tokenizer)
     assert isinstance(dataset, TransformedDataset)
 
-    model_spec = get_model_spec("transformer")
+    model_spec = MODEL_SPECS["transformer"]
     collate_fn_obj = get_target(model_spec.collate_fn_target)(tokenizer=tokenizer)
 
     dataloader_conf = dataset_conf.dataloader
@@ -164,7 +163,7 @@ def test_data_config_defaults():
     assert config.dataset.per_seq_size == 256
     assert config.dataset.charset == "@alpha"
     assert config.dataloader.batch_size == 32
-    assert config.dataloader.collate_fn is None
+    assert not hasattr(config.dataloader, "collate_fn")
 
 
 def test_prompt_completion_transform():

--- a/tests/models/transformer_test.py
+++ b/tests/models/transformer_test.py
@@ -147,7 +147,7 @@ def test_build_transformer_model_from_spec():
 
 def test_causal_lm_collate_fn():
     tokenizer = CharTokenizer()
-    collate = CausalLMCollateFn(tokenizer=tokenizer, pad_token_id=0, ignore_index=-100)
+    collate = CausalLMCollateFn(tokenizer=tokenizer)
 
     # Create pre-tokenized items as the dataset now produces
     src1 = "abc"

--- a/tests/models/transformer_test.py
+++ b/tests/models/transformer_test.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from trainite.config.registry import get_model_spec
+from trainite.config.registry import MODEL_SPECS
 from trainite.models.transformer import (
     Attention,
     CausalLMCollateFn,
@@ -139,7 +139,7 @@ def test_build_transformer_model():
 
 
 def test_build_transformer_model_from_spec():
-    spec = get_model_spec("transformer")
+    spec = MODEL_SPECS["transformer"]
     model_conf = spec.config_cls()
     model = instantiate(model_conf)
     assert isinstance(model, TransformerModel)

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -19,7 +19,6 @@ from trainite.config import (
     PreprocessorConfig,
     DatasetConfig,
     TransformConfig,
-    CollateFnConfig,
 )
 from trainite.datasets.string_reverse import DatapointModel
 from trainite.trainers.decoder_trainer import Trainer, _flatten
@@ -33,7 +32,7 @@ def create_trainer_from_config(config: ProjectConfig) -> Trainer:
     return Trainer(config)
 
 
-class MockComponent(ModelConfig, PreprocessorConfig, DatasetConfig, TransformConfig, CollateFnConfig):
+class MockComponent(ModelConfig, PreprocessorConfig, DatasetConfig, TransformConfig):
     pass
 
 
@@ -477,7 +476,7 @@ def test_decoder_trainer_test_without_val(project_config, temp_run_dir):
 
 
 def test_decoder_trainer_dataloader_collate_fn(project_config):
-    project_config.data.train.dataloader.collate_fn = cc("tests.trainers.decoder_trainer_test.dummy_collate_fn")
+    project_config.model.collate_fn_target = "tests.trainers.decoder_trainer_test.dummy_collate_fn"
     trainer = create_trainer_from_config(project_config)
     assert trainer.train_loader is not None
     assert trainer.train_loader.collate_fn is dummy_collate_fn
@@ -611,8 +610,8 @@ def test_decoder_trainer_dataloader_class_collate_fn(project_config):
         "tests.trainers.decoder_trainer_test.SimpleModel",
         vocab_size=10,
         hidden_size=8,
+        collate_fn_target="tests.trainers.decoder_trainer_test.DummyClassCollateFn",
     )
-    project_config.data.train.dataloader.collate_fn = cc("tests.trainers.decoder_trainer_test.DummyClassCollateFn")
     trainer = create_trainer_from_config(project_config)
     assert trainer.train_loader is not None
     assert isinstance(trainer.train_loader.collate_fn, DummyClassCollateFn)
@@ -646,9 +645,9 @@ def test_setup_inference_and_log_success(project_config, temp_run_dir):
         "tests.trainers.decoder_trainer_test.GenerativeModel",
         vocab_size=10,
         hidden_size=8,
+        collate_fn_target="trainite.models.transformer.CausalLMCollateFn",
     )
     transform = cc("tests.trainers.decoder_trainer_test.DummyTransform")
-    collate = cc("trainite.models.transformer.CausalLMCollateFn")
     project_config.data.train.dataset = cc(
         "tests.trainers.decoder_trainer_test.GenerativeDataset",
         size=16,
@@ -656,7 +655,6 @@ def test_setup_inference_and_log_success(project_config, temp_run_dir):
         vocab_size=10,
     )
     project_config.data.train.transform = transform
-    project_config.data.train.dataloader.collate_fn = collate
     project_config.data.val.dataset = cc(
         "tests.trainers.decoder_trainer_test.GenerativeDataset",
         size=8,
@@ -664,7 +662,6 @@ def test_setup_inference_and_log_success(project_config, temp_run_dir):
         vocab_size=10,
     )
     project_config.data.val.transform = transform
-    project_config.data.val.dataloader.collate_fn = collate
     trainer = create_trainer_from_config(project_config)
     assert trainer.max_inference_new_tokens == 32
     trainer.run()

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -282,15 +282,15 @@ def run_interactive_mode() -> None:
 
 
 def _update_targets(config: Any, rewrites: Sequence[tuple[str, str]]) -> None:
-    """Rewrite ``_target_`` import paths to point at the generated project's modules."""
-    if isinstance(config, BaseModel) and hasattr(config, "target"):
-        target = getattr(config, "target")
-        if isinstance(target, str):
-            for old_module, new_module in rewrites:
-                if target.startswith(old_module + "."):
-                    setattr(config, "target", new_module + target[len(old_module) :])
-                    break
-    elif isinstance(config, BaseModel):
+    """Rewrite ``_target_`` and ``collate_fn_target`` import paths to point at the generated project's modules."""
+    if isinstance(config, BaseModel):
+        for attr in ("target", "collate_fn_target"):
+            val = getattr(config, attr, None)
+            if isinstance(val, str):
+                for old_module, new_module in rewrites:
+                    if val.startswith(old_module + "."):
+                        setattr(config, attr, new_module + val[len(old_module) :])
+                        break
         for field in config.model_fields:
             if (val := getattr(config, field)) is not None:
                 _update_targets(val, rewrites)

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -12,17 +12,15 @@ from trainite.config import (
     OutputConfig,
     ProjectConfig,
 )
-from trainite.config.base import CollateFnConfig
 from trainite.config.registry import (
     REGISTRY,
+    ComponentSpec,
     DatasetSpec,
     ModelSpec,
-    PreProcessorSpec,
-    TrainerSpec,
-    get_dataset_spec,
-    get_model_spec,
-    get_preprocessor_spec,
-    get_trainer_spec,
+    MODEL_SPECS,
+    DATASET_SPECS,
+    TRAINER_SPECS,
+    PREPROCESSOR_SPECS,
 )
 from trainite.shared.utils import dump_config
 
@@ -185,8 +183,8 @@ def _module_rewrites(sources: dict[str, Path]) -> list[tuple[str, str]]:
 def _build_templates(
     model_spec: ModelSpec,
     dataset_spec: DatasetSpec,
-    trainer_spec: TrainerSpec,
-    preprocessor_spec: PreProcessorSpec | None,
+    trainer_spec: ComponentSpec,
+    preprocessor_spec: ComponentSpec | None,
     project_name: str,
 ) -> tuple[dict[str, str], list[tuple[str, str]]]:
     specs = [model_spec, dataset_spec, trainer_spec, preprocessor_spec]
@@ -343,11 +341,11 @@ def init_project(config: Init) -> None:
 
     output_config = OutputConfig(root=output_root, run_name=resolved_run_name)
 
-    model_spec = get_model_spec(model)
-    dataset_spec = get_dataset_spec(dataset)
-    trainer_spec = get_trainer_spec(trainer)
+    model_spec = MODEL_SPECS[model]
+    dataset_spec = DATASET_SPECS[dataset]
+    trainer_spec = TRAINER_SPECS[trainer]
     preprocessor_spec = (
-        get_preprocessor_spec(dataset_spec.preprocessor_spec_name) if dataset_spec.preprocessor_spec_name else None
+        PREPROCESSOR_SPECS[dataset_spec.preprocessor_spec_name] if dataset_spec.preprocessor_spec_name else None
     )
 
     # Build templates for the starter project
@@ -356,29 +354,11 @@ def init_project(config: Init) -> None:
     )
 
     # Instantiate configs from specs
-    model_component = model_spec.config_cls()
+    model_component = model_spec.config_cls(collate_fn_target=model_spec.collate_fn_target)
     data_config = dataset_spec.config_cls()
     trainer_component = trainer_spec.config_cls()
 
     preprocessor_component = preprocessor_spec.config_cls() if preprocessor_spec else None
-
-    # Inject model collator into data config dataloaders
-    if model_spec.collate_fn_target:
-        if model_spec.collate_fn_config_cls:
-            collate_fn_val = CollateFnConfig.model_validate(model_spec.collate_fn_config_cls())
-        else:
-            collate_fn_val = CollateFnConfig(_target_=model_spec.collate_fn_target)
-
-        def _inject_collate(config: Any):
-            dataloader = getattr(config, "dataloader", None)
-            if dataloader is not None:
-                dataloader.collate_fn = collate_fn_val
-            for split in ["train", "val", "test"]:
-                split_config = getattr(config, split, None)
-                if split_config is not None:
-                    _inject_collate(split_config)
-
-        _inject_collate(data_config)
 
     starter_config = ProjectConfig(
         preprocessor=preprocessor_component,

--- a/trainite/config/__init__.py
+++ b/trainite/config/__init__.py
@@ -9,7 +9,6 @@ from trainite.config.base import (
     PreprocessorConfig,
     DatasetConfig,
     TransformConfig,
-    CollateFnConfig,
     TrainerConfig,
     ProjectConfig,
 )
@@ -25,7 +24,6 @@ __all__ = [
     "PreprocessorConfig",
     "DatasetConfig",
     "TransformConfig",
-    "CollateFnConfig",
     "TrainerConfig",
     "ProjectConfig",
 ]

--- a/trainite/config/base.py
+++ b/trainite/config/base.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class ModelConfig(BaseModel):
     model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: str = Field(alias="_target_")
+    collate_fn_target: str | None = None
 
 
 class PreprocessorConfig(BaseModel):
@@ -18,11 +19,6 @@ class DatasetConfig(BaseModel):
 
 
 class TransformConfig(BaseModel):
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
-    target: str = Field(alias="_target_")
-
-
-class CollateFnConfig(BaseModel):
     model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: str = Field(alias="_target_")
 
@@ -44,7 +40,6 @@ class DataLoaderConfig(BaseModel):
     batch_size: int = Field(default=32, gt=0)
     shuffle: bool = False
     num_workers: int = Field(default=2, ge=0)
-    collate_fn: CollateFnConfig | None = None
 
 
 class SplitConfig(BaseModel):

--- a/trainite/config/datasets.py
+++ b/trainite/config/datasets.py
@@ -54,6 +54,5 @@ class StringReverseDataConfig(DataWithAutoSplit):
         default_factory=lambda: DataLoaderConfig(
             batch_size=32,
             shuffle=True,
-            collate_fn=None,
         )
     )

--- a/trainite/config/models.py
+++ b/trainite/config/models.py
@@ -1,6 +1,6 @@
 from pydantic import Field, ConfigDict
 from typing import Literal
-from trainite.config.base import ModelConfig, CollateFnConfig
+from trainite.config.base import ModelConfig
 
 
 class TransformerModelConfig(ModelConfig):
@@ -14,12 +14,3 @@ class TransformerModelConfig(ModelConfig):
     feedforward_dim: int = Field(default=128, gt=0)
     dropout: float = Field(default=0.1, ge=0.0, lt=1.0)
     max_seq_len: int = Field(default=128, gt=0)
-
-
-class CausalLMCollateFnConfig(CollateFnConfig):
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
-    target: Literal["trainite.models.transformer.CausalLMCollateFn", "models.transformer.CausalLMCollateFn"] = Field(
-        default="trainite.models.transformer.CausalLMCollateFn", alias="_target_"
-    )
-    ignore_index: int = Field(default=-100)
-    pad_token_id: int | None = Field(default=None)

--- a/trainite/config/registry.py
+++ b/trainite/config/registry.py
@@ -20,18 +20,9 @@ class ComponentSpec(BaseModel):
         return get_target(self.config_cls_path)
 
 
-class TrainerSpec(ComponentSpec):
-    pass
-
-
 class ModelSpec(ComponentSpec):
     builder_symbol: str
     collate_fn_target: str | None = None
-    collate_fn_config_cls_path: str | None = None
-
-    @property
-    def collate_fn_config_cls(self) -> type[BaseModel] | None:
-        return get_target(self.collate_fn_config_cls_path) if self.collate_fn_config_cls_path else None
 
 
 class DatasetSpec(ComponentSpec):
@@ -44,10 +35,6 @@ class DatasetSpec(ComponentSpec):
         return get_target(self.dataset_config_cls_path)
 
 
-class PreProcessorSpec(ComponentSpec):
-    pass
-
-
 MODEL_SPECS = {
     "transformer": ModelSpec(
         name="transformer",
@@ -56,7 +43,6 @@ MODEL_SPECS = {
         implementation_symbol="TransformerModel",
         builder_symbol="TransformerModel",
         collate_fn_target="trainite.models.transformer.CausalLMCollateFn",
-        collate_fn_config_cls_path="trainite.config.models.CausalLMCollateFnConfig",
         readme_template_path=Path("trainite/templates/components/models/transformer.md"),
     ),
 }
@@ -75,7 +61,7 @@ DATASET_SPECS = {
 }
 
 TRAINER_SPECS = {
-    "decoder-trainer": TrainerSpec(
+    "decoder-trainer": ComponentSpec(
         name="decoder_trainer",
         implementation_path=Path("trainite/trainers/decoder_trainer.py"),
         config_cls_path="trainite.config.trainers.TrainerConfig",
@@ -85,7 +71,7 @@ TRAINER_SPECS = {
 }
 
 PREPROCESSOR_SPECS = {
-    "char": PreProcessorSpec(
+    "char": ComponentSpec(
         name="char_tokenizer",
         implementation_path=Path("trainite/preprocessors/char_tokenizer.py"),
         config_cls_path="trainite.config.preprocessors.CharTokenizerConfig",
@@ -101,31 +87,3 @@ REGISTRY = {
     "trainers": TRAINER_SPECS,
     "preprocessors": PREPROCESSOR_SPECS,
 }
-
-
-def get_model_config_cls(name: str) -> type[BaseModel]:
-    return MODEL_SPECS[name].config_cls
-
-
-def get_dataset_config_cls(name: str) -> type[BaseModel]:
-    return DATASET_SPECS[name].dataset_config_cls
-
-
-def get_trainer_config_cls(name: str) -> type[BaseModel]:
-    return TRAINER_SPECS[name].config_cls
-
-
-def get_model_spec(name: str) -> ModelSpec:
-    return MODEL_SPECS[name]
-
-
-def get_dataset_spec(name: str) -> DatasetSpec:
-    return DATASET_SPECS[name]
-
-
-def get_trainer_spec(name: str) -> TrainerSpec:
-    return TRAINER_SPECS[name]
-
-
-def get_preprocessor_spec(name: str) -> PreProcessorSpec:
-    return PREPROCESSOR_SPECS[name]

--- a/trainite/models/transformer.py
+++ b/trainite/models/transformer.py
@@ -189,15 +189,11 @@ class TransformerModel(nn.Module):
 class CausalLMCollateFn:
     """Collate sequences for decoder-only autoregressive training."""
 
-    def __init__(
-        self,
-        tokenizer: Any,
-        pad_token_id: int | None = None,
-        ignore_index: int = -100,
-    ) -> None:
+    def __init__(self, tokenizer: Any) -> None:
         self.tokenizer = tokenizer
-        self.pad_token_id = pad_token_id if pad_token_id is not None else tokenizer.pad_token_id
-        self.ignore_index = ignore_index
+        pad_id = getattr(tokenizer, "pad_token_id", None)
+        self.pad_token_id = pad_id if pad_id is not None else 0
+        self.ignore_index = -100
 
     def __call__(self, batch: list[Any]) -> dict[str, torch.Tensor]:
         input_ids_list = []

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -74,6 +74,14 @@ def instantiate(config: BaseModel, **kwargs) -> Any:
 
     final_kwargs = {**params, **kwargs}
 
+    # Filter kwargs to only pass parameters accepted by the target_symbol
+    try:
+        sig = inspect.signature(target_symbol)
+        if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+            final_kwargs = {k: v for k, v in final_kwargs.items() if k in sig.parameters}
+    except Exception:
+        pass
+
     return target_symbol(**final_kwargs)
 
 
@@ -141,33 +149,38 @@ def create_dataloader(
     dl_config: Any,
     tokenizer: Any,
     shuffle: bool | None = None,
+    collate_fn_target: str | None = None,
 ) -> DataLoader:
-    dl_kwargs = dl_config.model_dump(exclude={"collate_fn", "shuffle"})
+    dl_kwargs = dl_config.model_dump(exclude={"shuffle"})
     if shuffle is None:
         shuffle = getattr(dl_config, "shuffle", False)
     collate_fn = None
-    collate_config = dl_config.collate_fn
-    if collate_config:
-        target_symbol = get_target(collate_config.target)
+    if collate_fn_target:
+        target_symbol = get_target(collate_fn_target)
         if isinstance(target_symbol, type):
-            collate_fn = instantiate(collate_config, tokenizer=tokenizer)
+            collate_fn = target_symbol(tokenizer=tokenizer)
         else:
             collate_fn = target_symbol
     return DataLoader(dataset, shuffle=shuffle, collate_fn=collate_fn, **dl_kwargs)
 
 
 def _loaders_from_splits(
-    data_config: DataConfigBase, tokenizer: Any
+    data_config: DataConfigBase,
+    tokenizer: Any,
+    collate_fn_target: str | None = None,
 ) -> tuple[DataLoader, DataLoader, DataLoader | None]:
     def _make(split_config: Any) -> DataLoader:
         ds = build_dataset(split_config.dataset, split_config.transform, tokenizer)
-        return create_dataloader(ds, split_config.dataloader, tokenizer)
+        return create_dataloader(ds, split_config.dataloader, tokenizer, collate_fn_target=collate_fn_target)
 
     return _make(data_config.train), _make(data_config.val), _make(data_config.test) if data_config.test else None
 
 
 def _loaders_from_ratios(
-    data_config: DataWithAutoSplit, tokenizer: Any, seed: int
+    data_config: DataWithAutoSplit,
+    tokenizer: Any,
+    seed: int,
+    collate_fn_target: str | None = None,
 ) -> tuple[DataLoader, DataLoader, DataLoader | None]:
     dataset = build_dataset(data_config.dataset, data_config.transform, tokenizer)
     total_len = len(dataset)  # type: ignore
@@ -185,16 +198,23 @@ def _loaders_from_ratios(
     )
     dl = data_config.dataloader
     return (
-        create_dataloader(train_ds, dl, tokenizer, shuffle=True),
-        create_dataloader(val_ds, dl, tokenizer, shuffle=False),
-        create_dataloader(test_ds, dl, tokenizer, shuffle=False) if test_len > 0 else None,
+        create_dataloader(train_ds, dl, tokenizer, shuffle=True, collate_fn_target=collate_fn_target),
+        create_dataloader(val_ds, dl, tokenizer, shuffle=False, collate_fn_target=collate_fn_target),
+        create_dataloader(test_ds, dl, tokenizer, shuffle=False, collate_fn_target=collate_fn_target)
+        if test_len > 0
+        else None,
     )
 
 
-def build_dataloaders(data_config: Any, tokenizer: Any, seed: int) -> tuple[DataLoader, DataLoader, DataLoader | None]:
+def build_dataloaders(
+    data_config: Any,
+    tokenizer: Any,
+    seed: int,
+    collate_fn_target: str | None = None,
+) -> tuple[DataLoader, DataLoader, DataLoader | None]:
     if isinstance(data_config, DataWithAutoSplit):
-        return _loaders_from_ratios(data_config, tokenizer, seed)
-    return _loaders_from_splits(data_config, tokenizer)
+        return _loaders_from_ratios(data_config, tokenizer, seed, collate_fn_target)
+    return _loaders_from_splits(data_config, tokenizer, collate_fn_target)
 
 
 # ==========================================

--- a/trainite/shared/utils.py
+++ b/trainite/shared/utils.py
@@ -53,6 +53,19 @@ def get_target(target_path: str) -> Any:
     return target_symbol
 
 
+def _inject_if_accepted(target_symbol: Any, **candidates: Any) -> dict[str, Any]:
+    """Inspects the target symbol's signature and filters the candidates to
+    only include those that are accepted by the target symbol.
+    """
+    try:
+        sig = inspect.signature(target_symbol)
+        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+            return candidates
+        return {k: v for k, v in candidates.items() if k in sig.parameters}
+    except Exception:
+        return candidates
+
+
 def instantiate(config: BaseModel, **kwargs) -> Any:
     """
     Instantiates a class or calls a function defined by a `_target_` key
@@ -73,14 +86,7 @@ def instantiate(config: BaseModel, **kwargs) -> Any:
     target_symbol = get_target(target_path)
 
     final_kwargs = {**params, **kwargs}
-
-    # Filter kwargs to only pass parameters accepted by the target_symbol
-    try:
-        sig = inspect.signature(target_symbol)
-        if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
-            final_kwargs = {k: v for k, v in final_kwargs.items() if k in sig.parameters}
-    except Exception:
-        pass
+    final_kwargs = _inject_if_accepted(target_symbol, **final_kwargs)
 
     return target_symbol(**final_kwargs)
 
@@ -110,16 +116,6 @@ def load_config(path: str | Path, config_cls: type[T]) -> T:
 # ==========================================
 # Builders (Dataset, Dataloader, Model Setup)
 # ==========================================
-
-
-# Inspects the target symbol's signature and filters the candidates to
-# only include those that are accepted by the target symbol.
-def _inject_if_accepted(target_symbol: Any, **candidates: Any) -> dict[str, Any]:
-    try:
-        sig = inspect.signature(target_symbol)
-        return {k: v for k, v in candidates.items() if k in sig.parameters}
-    except Exception:
-        return {}
 
 
 # Builds the model based on the provided configuration, tokenizer, and device.

--- a/trainite/trainers/decoder_trainer.py
+++ b/trainite/trainers/decoder_trainer.py
@@ -46,7 +46,10 @@ class Trainer:
         self.device: str | torch.device = idist.device() if config.device is None else config.device
         self.tokenizer = instantiate(config.preprocessor)
         self.train_loader, self.val_loader, self.test_loader = build_dataloaders(
-            config.data, self.tokenizer, config.seed
+            config.data,
+            self.tokenizer,
+            config.seed,
+            collate_fn_target=config.model.collate_fn_target,
         )
         self.model = build_model(
             config.model, self.device, vocab_size=self.tokenizer.vocab_size, pad_token_id=self.tokenizer.pad_token_id


### PR DESCRIPTION
This pull request refactors how component specifications (such as models, datasets, trainers, and preprocessors) are handled throughout the codebase. It removes the use of the `CollateFnConfig` and the associated `collate_fn` field from data loader configs, instead standardizing on a `collate_fn_target` string in model configs. The registry now exposes only the `*_SPECS` dictionaries, and all dynamic spec lookups are done directly through these dictionaries. This simplifies configuration and improves clarity around how collate functions are specified and injected.

**Component registry and configuration refactor:**

* Removed all `get_*_spec` and related dynamic registry lookup functions; all code now directly accesses `MODEL_SPECS`, `DATASET_SPECS`, `TRAINER_SPECS`, and `PREPROCESSOR_SPECS` for component specifications. [[1]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bL104-L131) [[2]](diffhunk://#diff-1e20c19b0f95a48591a0f35c025ef834b85ff6c4deaecb675a711f8499f1bf40L15-R23) [[3]](diffhunk://#diff-45a2090b635eb9df75918f4fcbde88a21e7b3d9ba4e6d7ec4a5d6bb7f6f92aa7L9-R9) [[4]](diffhunk://#diff-6f82c08d9b763ae03bec58afcb3a2855191b40da55e2902ac0ea2268d754a140L3-R3) [[5]](diffhunk://#diff-c2f4f8b4321a41e2c5a0e98a2f02dcb6035a6ab905de64800706b537c137bcf4L4-R4)
* Registry types for trainers and preprocessors are unified to use `ComponentSpec` instead of custom subclasses. [[1]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bL23-L34) [[2]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bL78-R64) [[3]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bL88-R74)

**Collate function configuration changes:**

* Removed the `CollateFnConfig` class and the `collate_fn` field from `DataLoaderConfig`; collate functions are now specified via a `collate_fn_target` string in the model config. [[1]](diffhunk://#diff-73352dfb97a0b9afb3ad346b22af2fdb5df6e72c73da6aa0df96d85c0a4c0cddR8) [[2]](diffhunk://#diff-73352dfb97a0b9afb3ad346b22af2fdb5df6e72c73da6aa0df96d85c0a4c0cddL25-L29) [[3]](diffhunk://#diff-73352dfb97a0b9afb3ad346b22af2fdb5df6e72c73da6aa0df96d85c0a4c0cddL47) [[4]](diffhunk://#diff-c90462a31c78a843f174e06c2c564385aa3cd0a5d38fdd758b926f63f0ce5d1cL12) [[5]](diffhunk://#diff-c90462a31c78a843f174e06c2c564385aa3cd0a5d38fdd758b926f63f0ce5d1cL28) [[6]](diffhunk://#diff-5fe1bff43e87ac8787af434b732a2f9207aec9f7e4d4f50c4a6896db476a4ec4L3-R3) [[7]](diffhunk://#diff-5fe1bff43e87ac8787af434b732a2f9207aec9f7e4d4f50c4a6896db476a4ec4L17-L25) [[8]](diffhunk://#diff-32fa89bcbe1d4457d1137a96864c33cf72544d189405be2568bd5215fbcaf801L57)
* The project initialization logic now injects the collate function into the model config using `collate_fn_target`, and no longer mutates dataloader configs.

**Test and usage updates:**

* All test files and project initialization code are updated to use the new registry access pattern and collate function specification. [[1]](diffhunk://#diff-45a2090b635eb9df75918f4fcbde88a21e7b3d9ba4e6d7ec4a5d6bb7f6f92aa7L37-R41) [[2]](diffhunk://#diff-c2f4f8b4321a41e2c5a0e98a2f02dcb6035a6ab905de64800706b537c137bcf4L103-R108) [[3]](diffhunk://#diff-c2f4f8b4321a41e2c5a0e98a2f02dcb6035a6ab905de64800706b537c137bcf4L167-R166) [[4]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627L480-R479) [[5]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627R613-L615) [[6]](diffhunk://#diff-3546af870c8a70aff1cd32740059f730c9a41560736d7e082573923b30016627R648-L667)

**Cleanup and simplification:**

* Removed unnecessary methods and configuration classes related to collate functions and component spec lookups. [[1]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bL23-L34) [[2]](diffhunk://#diff-f1e4797054e117a0de73729f410d0b1781a627ce2ff13b9d02d2cbf0e5fc1a4bL47-L50) [[3]](diffhunk://#diff-5fe1bff43e87ac8787af434b732a2f9207aec9f7e4d4f50c4a6896db476a4ec4L17-L25) [[4]](diffhunk://#diff-73352dfb97a0b9afb3ad346b22af2fdb5df6e72c73da6aa0df96d85c0a4c0cddL25-L29)

These changes streamline the configuration system, making it more explicit and less error-prone by removing indirection and redundant configuration layers.