### PR TITLE
multi-platform tests

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - "trainite/**"
       - "tests/**"
-      - "examples/**"
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/**"
@@ -15,7 +14,6 @@ on:
     paths:
       - "trainite/**"
       - "tests/**"
-      - "examples/**"
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/**"
@@ -23,13 +21,14 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -27,6 +27,7 @@ jobs:
         python-version: ["3.11"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -126,7 +126,7 @@ def test_generated_string_reversal_project_is_runnable() -> None:
                 [sys.executable, "main.py", "config.yaml"],
                 cwd=project_dir,
                 check=True,
-                timeout=60,
+                timeout=300,
                 capture_output=True,
                 text=True,
             )
@@ -136,7 +136,7 @@ def test_generated_string_reversal_project_is_runnable() -> None:
             pytest.fail("Generated project timed out")
 
         finally:
-            logging.shutdown()
+            logging.shutdown()  # Ensure all logging output is flushed before the temporary directory is cleaned up
 
 
 def test_cli_main_routing():

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,3 +1,4 @@
+import logging
 import py_compile
 import subprocess
 import sys
@@ -133,6 +134,9 @@ def test_generated_string_reversal_project_is_runnable() -> None:
             pytest.fail(f"Generated project failed to run:\nSTDOUT: {e.stdout}\nSTDERR: {e.stderr}")
         except subprocess.TimeoutExpired:
             pytest.fail("Generated project timed out")
+
+        finally:
+            logging.shutdown()
 
 
 def test_cli_main_routing():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import torch.utils.data
+import pytest
+
+# Store the original init method
+_original_dataloader_init = torch.utils.data.DataLoader.__init__
+
+
+def patched_dataloader_init(self, *args, **kwargs):
+    # Override num_workers to 0 to avoid process spawning overhead during tests
+    kwargs["num_workers"] = 0
+    _original_dataloader_init(self, *args, **kwargs)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def force_dataloader_num_workers_zero():
+    torch.utils.data.DataLoader.__init__ = patched_dataloader_init
+    yield
+    torch.utils.data.DataLoader.__init__ = _original_dataloader_init

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 import tempfile
 from pathlib import Path
@@ -194,6 +195,7 @@ def dummy_collate_fn(batch):
 def temp_run_dir():
     temp_dir = tempfile.mkdtemp()
     yield Path(temp_dir)
+    logging.shutdown()
     shutil.rmtree(temp_dir)
 
 

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -195,7 +195,7 @@ def dummy_collate_fn(batch):
 def temp_run_dir():
     temp_dir = tempfile.mkdtemp()
     yield Path(temp_dir)
-    logging.shutdown()
+    logging.shutdown()  # Ensure all logging handlers are flushed and closed before removing the directory
     shutil.rmtree(temp_dir)
 
 

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -395,6 +395,6 @@ def init_project(config: Init) -> None:
     for filename, content in templates.items():
         _write_file(resolved_project_dir / filename, content, force)
 
-    print("\n✔ Generated config.yaml")
+    print("\n Generated config.yaml")
     for filename in templates:
-        print(f"✔ Generated {filename}")
+        print(f" Generated {filename}")


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for CPU tests to improve test coverage and resource allocation. The most important changes are:

**Workflow triggers:**

* The workflow will no longer be triggered by changes to files in the `examples/**` directory.

**Test matrix and resource allocation:**

* The test matrix now includes multiple operating systems (`ubuntu-latest`, `macos-latest`, and `windows-latest`), expanding test coverage beyond just Ubuntu.
* The test job timeout has been increased from 30 to 60 minutes to accommodate potentially longer test runs across different platforms.
* The `runs-on` parameter is now set dynamically based on the operating system defined in the matrix, instead of being hardcoded to Ubuntu.