### PR TITLE
remove unnecessary global universal vocab

### DIFF
--- a/tests/preprocessors/char_test.py
+++ b/tests/preprocessors/char_test.py
@@ -1,16 +1,17 @@
 import torch
-from trainite.preprocessors import UNIVERSAL_VOCAB, CharTokenizer, CharTokenizerConfig
+from trainite.preprocessors import CharTokenizer, CharTokenizerConfig
+import string
 
 
 def test_char_tokenizer_vocab_size():
     tokenizer = CharTokenizer()
-    assert tokenizer.vocab_size == len(UNIVERSAL_VOCAB) + len(tokenizer.special_tokens)
+    assert tokenizer.vocab_size == len(string.printable) + len(tokenizer.special_tokens)
 
 
 def test_char_tokenizer_encode():
     tokenizer = CharTokenizer()
     encoded = tokenizer.encode("abc")
-    assert encoded == [5, 6, 7]
+    assert encoded == [15, 16, 17]
 
 
 def test_char_tokenizer_decode():
@@ -30,7 +31,7 @@ def test_char_tokenizer_special_tokens():
 
 def test_char_tokenizer_unk():
     tokenizer = CharTokenizer()
-    # Δ is not in the universal vocab, should map to UNK token ID 4
+    # Δ is not in the vocab, should map to UNK token ID 4
     assert tokenizer.encode("Δ") == [4]
     assert tokenizer.decode([4]) == "<UNK>"
 
@@ -80,7 +81,7 @@ def test_char_tokenizer_call_no_special_tokens():
     tokenizer = CharTokenizer()
     result = tokenizer("abc", add_special_tokens=False)
     assert len(result["input_ids"]) == 3
-    assert result["input_ids"] == [5, 6, 7]
+    assert result["input_ids"] == [15, 16, 17]
 
 
 def test_char_tokenizer_call_max_length_padding():

--- a/trainite/datasets/string_reverse.py
+++ b/trainite/datasets/string_reverse.py
@@ -7,11 +7,8 @@ import torch
 from pydantic import BaseModel, ConfigDict
 from torch.utils.data import Dataset
 
-# Hardcoded universal vocabulary: all printable ASCII characters
-UNIVERSAL_VOCAB = string.ascii_letters + string.digits + string.punctuation + " "
-
 CHARSET_PRESETS = {
-    "@universal": UNIVERSAL_VOCAB,
+    "@universal": string.printable,
     "@alpha": string.ascii_letters,
     "@alpha_lowercase": string.ascii_lowercase,
     "@alpha_uppercase": string.ascii_uppercase,
@@ -41,7 +38,7 @@ class StringReverseDataset(Dataset):
         seed: int = 42,
     ) -> None:
         if charset is None:
-            chars = UNIVERSAL_VOCAB
+            chars = string.printable
         elif charset in CHARSET_PRESETS:
             chars = CHARSET_PRESETS[charset]
         else:

--- a/trainite/preprocessors/__init__.py
+++ b/trainite/preprocessors/__init__.py
@@ -1,4 +1,4 @@
-from trainite.preprocessors.char_tokenizer import UNIVERSAL_VOCAB, CharTokenizer
+from trainite.preprocessors.char_tokenizer import CharTokenizer
 from trainite.config.preprocessors import CharTokenizerConfig
 
-__all__ = ["CharTokenizer", "CharTokenizerConfig", "UNIVERSAL_VOCAB"]
+__all__ = ["CharTokenizer", "CharTokenizerConfig"]

--- a/trainite/preprocessors/char_tokenizer.py
+++ b/trainite/preprocessors/char_tokenizer.py
@@ -1,17 +1,12 @@
 import string
-
 import torch
-
-
-# Hardcoded universal vocabulary: all printable ASCII characters
-UNIVERSAL_VOCAB = string.ascii_letters + string.digits + string.punctuation + " "
 
 
 class CharTokenizer:
     """A simple character-level tokenizer with a hardcoded universal vocabulary.
     Consists of all printable ASCII characters, plus special tokens for padding, beginning of sequence, separator, end of sequence, and unknown characters.
 
-    Maps each character in UNIVERSAL_VOCAB to a unique integer ID.
+    Maps each character in string.printable to a unique integer ID.
     ID 0 is reserved as the <PAD> token.
     ID 1 is reserved as the <BOS> token.
     ID 2 is reserved as the <SEP> token.
@@ -26,8 +21,8 @@ class CharTokenizer:
         self.eos_token_id = 3
         self.unk_token_id = 4
 
-        self.char_to_id: dict[str, int] = {c: i + 5 for i, c in enumerate(UNIVERSAL_VOCAB)}
-        self.id_to_char: dict[int, str] = {i + 5: c for i, c in enumerate(UNIVERSAL_VOCAB)}
+        self.char_to_id: dict[str, int] = {c: i + 5 for i, c in enumerate(string.printable)}
+        self.id_to_char: dict[int, str] = {i + 5: c for i, c in enumerate(string.printable)}
 
         self.special_tokens: dict[int, str] = {
             self.pad_token_id: "<PAD>",
@@ -43,7 +38,7 @@ class CharTokenizer:
     @property
     def vocab_size(self) -> int:
         """Number of unique tokens in the vocabulary (includes special tokens)."""
-        return len(UNIVERSAL_VOCAB) + len(self.special_tokens)
+        return len(string.printable) + len(self.special_tokens)
 
     def encode(self, text: str) -> list[int]:
         """Convert a string to a list of token IDs, mapping unrecognized characters to UNK."""


### PR DESCRIPTION
This pull request updates the character-level tokenizer to use Python's built-in `string.printable` as its vocabulary instead of a manually constructed set of printable ASCII characters. The change affects the tokenizer implementation, its exports, and all related tests and dataset presets.

**CharTokenizer vocabulary update:**

* The `CharTokenizer` now uses `string.printable` for its vocabulary, replacing the previous hardcoded `UNIVERSAL_VOCAB` [[1]](diffhunk://#diff-e51910ac13c0ffa4666da8fb8aaea814821f473cd148933ae98f5d4ee2f627bcL2-R9) [[2]](diffhunk://#diff-e51910ac13c0ffa4666da8fb8aaea814821f473cd148933ae98f5d4ee2f627bcL29-R25) [[3]](diffhunk://#diff-e51910ac13c0ffa4666da8fb8aaea814821f473cd148933ae98f5d4ee2f627bcL46-R41).
* All references to `UNIVERSAL_VOCAB` are removed from the codebase and test suite [[1]](diffhunk://#diff-88716a5a40b342201e5a669802ab0b0aa759a429ed5e918651c7d8c785ca89eaL1-R4) [[2]](diffhunk://#diff-02d1f4729352722fff3711dbb6de86139fea91875a754dfd489195588faf609aL2-R14) [[3]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L10-R11) [[4]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L44-R41).

**Test and export adjustments:**

* All tests for the tokenizer are updated to match the new vocabulary, including expected token IDs and vocabulary size calculations [[1]](diffhunk://#diff-02d1f4729352722fff3711dbb6de86139fea91875a754dfd489195588faf609aL2-R14) [[2]](diffhunk://#diff-02d1f4729352722fff3711dbb6de86139fea91875a754dfd489195588faf609aL83-R84) [[3]](diffhunk://#diff-02d1f4729352722fff3711dbb6de86139fea91875a754dfd489195588faf609aL33-R34).
* The dataset preset in `string_reverse.py` now uses `string.printable` for the `@universal` charset and as the default charset [[1]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L10-R11) [[2]](diffhunk://#diff-e0dac8bceead0c2b475a6440a83d3cb3f966218558961b9832d2eeb75dbb4250L44-R41).
* The `UNIVERSAL_VOCAB` symbol is removed from the public API exports (`__all__`) in `trainite/preprocessors/__init__.py`.