### PR TITLE
Add BasicTransformerModel & RoPETransformerModel and enable multi-model selection

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -12,12 +12,14 @@ from trainite.config.registry import MODEL_SPECS, DATASET_SPECS, PREPROCESSOR_SP
 
 
 @pytest.mark.parametrize(
-    "model,dataset,trainer",
+    "models,dataset,trainer",
     [
-        ("transformer", "string-reverse", "decoder-trainer"),
+        (["basic-transformer"], "string-reverse", "decoder-trainer"),
+        (["rope-transformer"], "string-reverse", "decoder-trainer"),
+        (["rope-transformer", "basic-transformer"], "string-reverse", "decoder-trainer"),
     ],
 )
-def test_init_generates_valid_project(model: str, dataset: str, trainer: str) -> None:
+def test_init_generates_valid_project(models: list[str], dataset: str, trainer: str) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         project_dir = Path(temp_dir) / "demo-project"
         # Run trainite init
@@ -27,7 +29,7 @@ def test_init_generates_valid_project(model: str, dataset: str, trainer: str) ->
             "trainite.cli",
             "init",
             "--model",
-            model,
+            *models,
             "--dataset",
             dataset,
             "--trainer",
@@ -37,7 +39,7 @@ def test_init_generates_valid_project(model: str, dataset: str, trainer: str) ->
         subprocess.run(cmd, check=True, timeout=60)
 
         dataset_spec = DATASET_SPECS[dataset]
-        model_spec = MODEL_SPECS[model]
+        model_specs = [MODEL_SPECS[m] for m in models]
         trainer_spec = TRAINER_SPECS[trainer]
         preprocessor_spec = (
             PREPROCESSOR_SPECS[dataset_spec.preprocessor_spec_name] if dataset_spec.preprocessor_spec_name else None
@@ -47,7 +49,7 @@ def test_init_generates_valid_project(model: str, dataset: str, trainer: str) ->
         expected_files = [
             "config.yaml",
             "config.py",
-            f"models/{model_spec.name}.py",
+            *[f"models/{spec.name}.py" for spec in model_specs],
             f"datasets/{dataset_spec.name}.py",
             "datasets/transformed.py",
             "trainer.py",
@@ -61,16 +63,19 @@ def test_init_generates_valid_project(model: str, dataset: str, trainer: str) ->
             if filename is not None:
                 assert (project_dir / filename).exists(), f"{filename} missing"
 
-        # Check that targets inside config.yaml are rewritten correctly
+        # Check that target inside config.yaml is rewritten correctly and points to primary model
         with open(project_dir / "config.yaml", "r") as f:
             generated_config = yaml.safe_load(f)
-        assert generated_config["model"]["_target_"].startswith("models.")
+        primary_spec = model_specs[0]
+        assert (
+            generated_config["model"]["_target_"] == f"models.{primary_spec.name}.{primary_spec.implementation_symbol}"
+        )
         assert generated_config["model"]["collate_fn_target"].startswith("models.")
 
         # Check if python files are parseable
         python_files = [
             "config.py",
-            f"models/{model_spec.name}.py",
+            *[f"models/{spec.name}.py" for spec in model_specs],
             f"datasets/{dataset_spec.name}.py",
             "datasets/transformed.py",
             "trainer.py",
@@ -90,7 +95,7 @@ def test_generated_string_reversal_project_is_runnable() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         project_dir = Path(temp_dir) / "runnable-project"
 
-        # 1. Generate project
+        # 1. Generate project with multiple models
         subprocess.run(
             [
                 sys.executable,
@@ -98,7 +103,8 @@ def test_generated_string_reversal_project_is_runnable() -> None:
                 "trainite.cli",
                 "init",
                 "--model",
-                "transformer",
+                "rope-transformer",
+                "basic-transformer",
                 "--dataset",
                 "string-reverse",
                 "--trainer",
@@ -126,7 +132,6 @@ def test_generated_string_reversal_project_is_runnable() -> None:
             yaml.safe_dump(config, f)
 
         # 3. Run the generated main.py
-
         try:
             subprocess.run(
                 [sys.executable, "main.py", "config.yaml"],
@@ -142,7 +147,7 @@ def test_generated_string_reversal_project_is_runnable() -> None:
             pytest.fail("Generated project timed out")
 
         finally:
-            logging.shutdown()  # Ensure all logging output is flushed before the temporary directory is cleaned up
+            logging.shutdown()
 
 
 def test_cli_main_routing():
@@ -162,7 +167,8 @@ def test_cli_main_routing():
             argv=[
                 "init",
                 "--model",
-                "transformer",
+                "rope-transformer",
+                "basic-transformer",
                 "--dataset",
                 "string-reverse",
                 "--trainer",
@@ -197,3 +203,10 @@ def test_import_without_dependencies() -> None:
         text=True,
     )
     assert "is not a Python type" not in result.stderr
+
+
+def test_duplicate_models_raises_error():
+    from trainite.cli.init import Init
+
+    with pytest.raises(ValueError, match="Duplicate model entries are not allowed"):
+        Init(model=("rope-transformer", "rope-transformer"))

--- a/tests/datasets/string_reverse_test.py
+++ b/tests/datasets/string_reverse_test.py
@@ -105,7 +105,7 @@ def test_config_build_string_reverse_dataset():
     dataset = build_dataset(dataset_conf.dataset, dataset_conf.transform, tokenizer)
     assert isinstance(dataset, TransformedDataset)
 
-    model_spec = MODEL_SPECS["transformer"]
+    model_spec = MODEL_SPECS["rope-transformer"]
     collate_fn_obj = get_target(model_spec.collate_fn_target)(tokenizer=tokenizer)
 
     dataloader_conf = dataset_conf.dataloader

--- a/tests/models/transformer_test.py
+++ b/tests/models/transformer_test.py
@@ -1,14 +1,32 @@
 import pytest
 import torch
 from trainite.config.registry import MODEL_SPECS
-from trainite.models.transformer import (
-    Attention,
-    CausalLMCollateFn,
-    RotaryEmbedding,
-    TransformerBlock,
-    TransformerModel,
-)
 from trainite.datasets.string_reverse import DatapointModel
+from trainite.models.basic_transformer import (
+    Attention as BasicAttention,
+)
+from trainite.models.basic_transformer import (
+    BasicTransformerModel,
+)
+from trainite.models.basic_transformer import (
+    CausalLMCollateFn as BasicCausalLMCollateFn,
+)
+from trainite.models.basic_transformer import (
+    TransformerBlock as BasicTransformerBlock,
+)
+from trainite.models.rope_transformer import (
+    Attention as RoPEAttention,
+)
+from trainite.models.rope_transformer import (
+    CausalLMCollateFn as RoPECausalLMCollateFn,
+)
+from trainite.models.rope_transformer import (
+    RoPETransformerModel,
+    RotaryEmbedding,
+)
+from trainite.models.rope_transformer import (
+    TransformerBlock as RoPETransformerBlock,
+)
 from trainite.preprocessors.char_tokenizer import CharTokenizer
 from trainite.shared.utils import instantiate
 
@@ -41,115 +59,122 @@ def test_rotary_embedding():
         RotaryEmbedding(7, max_seq_len)
 
 
-def test_attention():
+@pytest.mark.parametrize("attn_cls,uses_rope", [(BasicAttention, False), (RoPEAttention, True)])
+def test_attention_forward(attn_cls, uses_rope):
     embed_dim = 16
     num_heads = 2
     head_dim = embed_dim // num_heads
-    attn = Attention(embed_dim, num_heads)
+    attn = attn_cls(embed_dim, num_heads)
     x = torch.randn(2, 10, embed_dim)
 
-    rope = RotaryEmbedding(head_dim, 16)
-    cos, sin = rope(x, seq_len=10)
+    kwargs = {}
+    if uses_rope:
+        rope = RotaryEmbedding(head_dim, 16)
+        cos, sin = rope(x, seq_len=10)
+        kwargs = {"cos": cos, "sin": sin}
 
-    # Test causal attention (default when padding_mask is None)
+    # Test causal attention
     attn.eval()
-    output, context = attn(x, cos, sin)
+    output, context = attn(x, **kwargs)
     assert output.shape == x.shape
 
     # Test with padding mask
-    # padding_mask shape (B, 1, 1, S)
     padding_mask = torch.ones(2, 1, 1, 10, dtype=torch.bool)
-    padding_mask[:, :, :, -2:] = False  # Mask last 2 tokens
-    output, context = attn(x, cos, sin, padding_mask=padding_mask)
+    padding_mask[:, :, :, -2:] = False
+    output, context = attn(x, padding_mask=padding_mask, **kwargs)
     assert output.shape == x.shape
 
-    # Non-divisible embed_dim should raise an assertion error
     with pytest.raises(ValueError, match="embed_dim must be divisible by num_heads."):
-        Attention(15, 2)
+        attn_cls(15, 2)
 
 
-def test_transformer_block():
+@pytest.mark.parametrize("block_cls,uses_rope", [(BasicTransformerBlock, False), (RoPETransformerBlock, True)])
+def test_transformer_block_forward(block_cls, uses_rope):
     d_model = 16
     num_heads = 2
     feedforward_dim = 32
     head_dim = d_model // num_heads
-    block = TransformerBlock(d_model, num_heads, feedforward_dim)
+    block = block_cls(d_model, num_heads, feedforward_dim)
     x = torch.randn(2, 10, d_model)
 
-    rope = RotaryEmbedding(head_dim, 16)
-    cos, sin = rope(x, seq_len=10)
+    kwargs = {}
+    if uses_rope:
+        rope = RotaryEmbedding(head_dim, 16)
+        cos, sin = rope(x, seq_len=10)
+        kwargs = {"cos": cos, "sin": sin}
 
-    output = block(x, cos, sin)
+    output = block(x, **kwargs)
     assert output.shape == x.shape
 
 
-def test_attention_context_and_dropout_behavior():
+@pytest.mark.parametrize("attn_cls,uses_rope", [(BasicAttention, False), (RoPEAttention, True)])
+def test_attention_context_and_dropout_behavior(attn_cls, uses_rope):
     embed_dim = 16
     num_heads = 2
     head_dim = embed_dim // num_heads
-    # use noticeable dropout so behavior is observable
-    attn = Attention(embed_dim, num_heads, dropout=0.5)
+    attn = attn_cls(embed_dim, num_heads, dropout=0.5)
     x = torch.randn(2, 10, embed_dim)
 
-    rope = RotaryEmbedding(head_dim, 16)
-    cos, sin = rope(x, seq_len=10)
+    kwargs = {}
+    if uses_rope:
+        rope = RotaryEmbedding(head_dim, 16)
+        cos, sin = rope(x, seq_len=10)
+        kwargs = {"cos": cos, "sin": sin}
 
-    # context shape should match (B, S, C)
-    output, context = attn(x, cos, sin)
+    output, context = attn(x, **kwargs)
     assert context.shape == x.shape
 
-    # Dropout should be disabled in eval mode (deterministic outputs across different seeds)
     attn.eval()
     torch.manual_seed(0)
-    out1, _ = attn(x, cos, sin)
+    out1, _ = attn(x, **kwargs)
     torch.manual_seed(1)
-    out2, _ = attn(x, cos, sin)
+    out2, _ = attn(x, **kwargs)
     assert torch.allclose(out1, out2)
 
-    # In train mode with different seeds outputs are expected to differ due to dropout randomness
     attn.train()
     torch.manual_seed(0)
-    out3, _ = attn(x, cos, sin)
+    out3, _ = attn(x, **kwargs)
     torch.manual_seed(1)
-    out4, _ = attn(x, cos, sin)
-    # It's extremely unlikely these are exactly equal when dropout is active
+    out4, _ = attn(x, **kwargs)
     assert not torch.allclose(out3, out4)
 
 
-def test_transformer_model():
+@pytest.mark.parametrize("model_cls", [BasicTransformerModel, RoPETransformerModel])
+def test_transformer_model_forward(model_cls):
     vocab_size = 10
     hidden_size = 16
-    model = TransformerModel(vocab_size=vocab_size, hidden_size=hidden_size)
+    model = model_cls(vocab_size=vocab_size, hidden_size=hidden_size)
 
     input_ids = torch.randint(1, vocab_size, (2, 10))
     model.eval()
     output = model(input_ids)
-    # output shape (B, S, vocab_size)
     assert output.shape == (2, 10, vocab_size)
 
-    # Test with padding
-    input_ids[0, -2:] = 0  # padding_idx=0
-    output = model(input_ids)
+    # Test with attention mask / padding
+    attention_mask = torch.ones(2, 10, dtype=torch.long)
+    attention_mask[0, :3] = 0
+    input_ids[0, :3] = 0
+
+    output = model(input_ids, attention_mask=attention_mask)
     assert output.shape == (2, 10, vocab_size)
 
 
-def test_build_transformer_model():
-    model = TransformerModel(vocab_size=10, hidden_size=16)
-    assert isinstance(model, TransformerModel)
-
-
-def test_build_transformer_model_from_spec():
-    spec = MODEL_SPECS["transformer"]
+@pytest.mark.parametrize(
+    "spec_name,expected_cls",
+    [("basic-transformer", BasicTransformerModel), ("rope-transformer", RoPETransformerModel)],
+)
+def test_build_transformer_models_from_specs(spec_name, expected_cls):
+    spec = MODEL_SPECS[spec_name]
     model_conf = spec.config_cls()
     model = instantiate(model_conf)
-    assert isinstance(model, TransformerModel)
+    assert isinstance(model, expected_cls)
 
 
-def test_causal_lm_collate_fn():
+@pytest.mark.parametrize("collate_cls", [BasicCausalLMCollateFn, RoPECausalLMCollateFn])
+def test_causal_lm_collate_fn(collate_cls):
     tokenizer = CharTokenizer()
-    collate = CausalLMCollateFn(tokenizer=tokenizer)
+    collate = collate_cls(tokenizer=tokenizer)
 
-    # Create pre-tokenized items as the dataset now produces
     src1 = "abc"
     tgt1 = "cba"
     src2 = "d"
@@ -181,10 +206,5 @@ def test_causal_lm_collate_fn():
     assert collated["input_ids"].ndim == 2
     assert collated["labels"].ndim == 2
     assert collated["input_ids"].shape == collated["labels"].shape
-
-    # Max sequence length:
-    # "abc" (3) -> <bos>abc<sep>cba<eos> = 9 tokens, input_ids=8, labels=8
-    # "d" (1) -> <bos>d<sep>d<eos> = 5 tokens, input_ids=4, labels=4
-    # Max length = 8, shorter padded on left
     assert collated["input_ids"].shape == (2, 8)
     assert (collated["input_ids"][1, :4] == tokenizer.pad_token_id).all()

--- a/tests/trainers/decoder_trainer_test.py
+++ b/tests/trainers/decoder_trainer_test.py
@@ -652,7 +652,7 @@ def test_setup_inference_and_log_success(project_config, temp_run_dir):
         "tests.trainers.decoder_trainer_test.GenerativeModel",
         vocab_size=10,
         hidden_size=8,
-        collate_fn_target="trainite.models.transformer.CausalLMCollateFn",
+        collate_fn_target="trainite.models.rope_transformer.CausalLMCollateFn",
     )
     transform = cc("tests.trainers.decoder_trainer_test.DummyTransform")
     project_config.data.train.dataset = cc(

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -6,7 +6,7 @@ import questionary
 import tomlkit
 import tyro
 from packaging.requirements import Requirement
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from trainite.config import (
     OutputConfig,
@@ -66,6 +66,20 @@ def _prompt_choice(prompt: str, choices: Sequence[str], default: str, instructio
     ).ask()
     if result is None:
         raise SystemExit(0)
+    return result
+
+
+def _prompt_multi_choice(
+    prompt: str, choices: Sequence[str], default: Sequence[str] | None = None, instruction: str | None = None
+) -> list[str]:
+    formatted_choices = [questionary.Choice(c, checked=(c in default if default else False)) for c in choices]
+    result = questionary.checkbox(
+        prompt,
+        choices=formatted_choices,
+        instruction=instruction,
+    ).ask()
+    if result is None or len(result) == 0:
+        raise SystemExit("At least one model must be selected.")
     return result
 
 
@@ -181,13 +195,13 @@ def _module_rewrites(sources: dict[str, Path]) -> list[tuple[str, str]]:
 
 
 def _build_templates(
-    model_spec: ModelSpec,
+    model_specs: Sequence[ModelSpec],
     dataset_spec: DatasetSpec,
     trainer_spec: ComponentSpec,
     preprocessor_spec: ComponentSpec | None,
     project_name: str,
 ) -> tuple[dict[str, str], list[tuple[str, str]]]:
-    specs = [model_spec, dataset_spec, trainer_spec, preprocessor_spec]
+    specs = [*model_specs, dataset_spec, trainer_spec, preprocessor_spec]
     spec_deps = set()
     for spec in specs:
         if spec is not None:
@@ -201,15 +215,20 @@ def _build_templates(
         final_deps.add(val)
 
     # Generated file -> source file it is copied from
-    sources = {
-        f"models/{model_spec.name}.py": model_spec.implementation_path,
-        f"datasets/{dataset_spec.name}.py": dataset_spec.implementation_path,
-        "datasets/transformed.py": Path("trainite/datasets/transformed.py"),
-        "trainer.py": trainer_spec.implementation_path,
-        "utils.py": Path("trainite/shared/utils.py"),
-        "main.py": Path("trainite/shared/main.py"),
-        "config.py": Path("trainite/config/base.py"),
-    }
+    sources: dict[str, Path] = {}
+    for spec in model_specs:
+        sources[f"models/{spec.name}.py"] = spec.implementation_path
+
+    sources.update(
+        {
+            f"datasets/{dataset_spec.name}.py": dataset_spec.implementation_path,
+            "datasets/transformed.py": Path("trainite/datasets/transformed.py"),
+            "trainer.py": trainer_spec.implementation_path,
+            "utils.py": Path("trainite/shared/utils.py"),
+            "main.py": Path("trainite/shared/main.py"),
+            "config.py": Path("trainite/config/base.py"),
+        }
+    )
     if preprocessor_spec:
         sources[f"preprocessors/{preprocessor_spec.name}.py"] = preprocessor_spec.implementation_path
 
@@ -221,10 +240,13 @@ def _build_templates(
             return _render_template(PROJECT_ROOT / spec.readme_template_path)
         return ""
 
+    model_names_str = ", ".join(spec.name for spec in model_specs)
+    model_docs_str = "\n\n".join(f"#### {spec.name}\n{_docs(spec)}" for spec in model_specs)
+
     readme_replacements = [
         ("{{project_name}}", project_name),
-        ("{{model_name}}", model_spec.name),
-        ("{{model_docs}}", _docs(model_spec)),
+        ("{{model_name}}", model_names_str),
+        ("{{model_docs}}", model_docs_str),
         ("{{dataset_name}}", dataset_spec.name),
         ("{{dataset_docs}}", _docs(dataset_spec)),
         ("{{trainer_name}}", trainer_spec.name),
@@ -248,7 +270,12 @@ def run_interactive_mode() -> None:
         "my-cool-experiment",
         "Directory to create the starter project in \n",
     )
-    model = _prompt_choice("Model:", MODEL_CHOICES, MODEL_CHOICES[0], "Starter model template to use")
+    models = _prompt_multi_choice(
+        "Model(s):",
+        MODEL_CHOICES,
+        default=["rope-transformer"],
+        instruction="Select starter model template(s) to include (use space to select)",
+    )
     dataset = _prompt_choice(
         "Dataset:",
         DATASET_CHOICES,
@@ -264,13 +291,13 @@ def run_interactive_mode() -> None:
     output_root = _prompt_text("Output directory:", "outputs", "Output directory for generated files \n")
     run_name = _prompt_text(
         "Run name:",
-        f"{model}__{dataset}",
+        f"{models[0]}__{dataset}",
         "Run name for generated config (used in output paths and logging) \n",
     )
 
     config = Init(
         project_dir=project_dir,
-        model=model,
+        model=tuple(models),
         dataset=dataset,
         trainer=trainer,
         output_root=output_root,
@@ -304,7 +331,7 @@ class Init(BaseModel):
 
     Args:
         project_dir: Directory to create the starter project in.
-        model: Starter model template to use.
+        model: Starter model template(s) to use.
         dataset: Starter dataset template to use.
         trainer: Starter trainer template to use.
         output_root: Output root for generated config.
@@ -313,12 +340,25 @@ class Init(BaseModel):
     """
 
     project_dir: tyro.conf.Positional[str] = "my-cool-experiment"
-    model: ModelType = "transformer"
+    model: tuple[ModelType, ...] = ("rope-transformer",)
     dataset: DatasetType = "string-reverse"
     trainer: TrainerType = "decoder-trainer"
     output_root: str = "outputs"
     run_name: str = ""
     force: bool = False
+
+    @field_validator("model", mode="before")
+    @classmethod
+    def validate_models(cls, v: Any) -> tuple[str, ...]:
+        if isinstance(v, str):
+            v = (v,)
+        if isinstance(v, (list, tuple)):
+            if not v:
+                raise ValueError("At least one model must be specified.")
+            if len(v) != len(set(v)):
+                raise ValueError("Duplicate model entries are not allowed.")
+            return tuple(v)
+        return v
 
 
 def init_project(config: Init) -> None:
@@ -329,19 +369,21 @@ def init_project(config: Init) -> None:
     """
 
     project_dir = config.project_dir
-    model = config.model
+    models = config.model
     dataset = config.dataset
     trainer = config.trainer
     output_root = config.output_root
     run_name = config.run_name
     force = config.force
 
-    resolved_run_name = run_name or f"{model}__{dataset}"
+    primary_model = models[0]
+    resolved_run_name = run_name or f"{primary_model}__{dataset}"
     resolved_project_dir = _project_directory(project_dir, force)
 
     output_config = OutputConfig(root=output_root, run_name=resolved_run_name)
 
-    model_spec = MODEL_SPECS[model]
+    model_specs = [MODEL_SPECS[m] for m in models]
+    primary_model_spec = model_specs[0]
     dataset_spec = DATASET_SPECS[dataset]
     trainer_spec = TRAINER_SPECS[trainer]
     preprocessor_spec = (
@@ -350,11 +392,11 @@ def init_project(config: Init) -> None:
 
     # Build templates for the starter project
     templates, rewrites = _build_templates(
-        model_spec, dataset_spec, trainer_spec, preprocessor_spec, resolved_project_dir.name
+        model_specs, dataset_spec, trainer_spec, preprocessor_spec, resolved_project_dir.name
     )
 
-    # Instantiate configs from specs
-    model_component = model_spec.config_cls(collate_fn_target=model_spec.collate_fn_target)
+    # Instantiate configs from specs (primary model is used for default config.yaml)
+    model_component = primary_model_spec.config_cls(collate_fn_target=primary_model_spec.collate_fn_target)
     data_config = dataset_spec.config_cls()
     trainer_component = trainer_spec.config_cls()
 

--- a/trainite/config/models.py
+++ b/trainite/config/models.py
@@ -1,13 +1,34 @@
-from pydantic import Field, ConfigDict
 from typing import Literal
+
+from pydantic import ConfigDict, Field
+
 from trainite.config.base import ModelConfig
 
 
-class TransformerModelConfig(ModelConfig):
+class BasicTransformerModelConfig(ModelConfig):
+    """Configuration for the BasicTransformerModel (absolute positional encoding)."""
+
     model_config = ConfigDict(extra="allow", validate_assignment=True)
-    target: Literal["trainite.models.transformer.TransformerModel", "models.transformer.TransformerModel"] = Field(
-        default="trainite.models.transformer.TransformerModel", alias="_target_"
-    )
+    target: Literal[
+        "trainite.models.basic_transformer.BasicTransformerModel",
+        "models.basic_transformer.BasicTransformerModel",
+    ] = Field(default="trainite.models.basic_transformer.BasicTransformerModel", alias="_target_")
+    hidden_size: int = Field(default=64, gt=0)
+    num_layers: int = Field(default=2, gt=0)
+    num_heads: int = Field(default=2, gt=0)
+    feedforward_dim: int = Field(default=128, gt=0)
+    dropout: float = Field(default=0.1, ge=0.0, lt=1.0)
+    max_seq_len: int = Field(default=128, gt=0)
+
+
+class RoPETransformerModelConfig(ModelConfig):
+    """Configuration for the RoPETransformerModel (rotary positional embeddings)."""
+
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+    target: Literal[
+        "trainite.models.rope_transformer.RoPETransformerModel",
+        "models.rope_transformer.RoPETransformerModel",
+    ] = Field(default="trainite.models.rope_transformer.RoPETransformerModel", alias="_target_")
     hidden_size: int = Field(default=64, gt=0)
     num_layers: int = Field(default=2, gt=0)
     num_heads: int = Field(default=2, gt=0)

--- a/trainite/config/registry.py
+++ b/trainite/config/registry.py
@@ -36,14 +36,23 @@ class DatasetSpec(ComponentSpec):
 
 
 MODEL_SPECS = {
-    "transformer": ModelSpec(
-        name="transformer",
-        implementation_path=Path("trainite/models/transformer.py"),
-        config_cls_path="trainite.config.models.TransformerModelConfig",
-        implementation_symbol="TransformerModel",
-        builder_symbol="TransformerModel",
-        collate_fn_target="trainite.models.transformer.CausalLMCollateFn",
-        readme_template_path=Path("trainite/templates/components/models/transformer.md"),
+    "basic-transformer": ModelSpec(
+        name="basic_transformer",
+        implementation_path=Path("trainite/models/basic_transformer.py"),
+        config_cls_path="trainite.config.models.BasicTransformerModelConfig",
+        implementation_symbol="BasicTransformerModel",
+        builder_symbol="BasicTransformerModel",
+        collate_fn_target="trainite.models.basic_transformer.CausalLMCollateFn",
+        readme_template_path=Path("trainite/templates/components/models/basic_transformer.md"),
+    ),
+    "rope-transformer": ModelSpec(
+        name="rope_transformer",
+        implementation_path=Path("trainite/models/rope_transformer.py"),
+        config_cls_path="trainite.config.models.RoPETransformerModelConfig",
+        implementation_symbol="RoPETransformerModel",
+        builder_symbol="RoPETransformerModel",
+        collate_fn_target="trainite.models.rope_transformer.CausalLMCollateFn",
+        readme_template_path=Path("trainite/templates/components/models/rope_transformer.md"),
     ),
 }
 

--- a/trainite/models/__init__.py
+++ b/trainite/models/__init__.py
@@ -1,5 +1,7 @@
-from trainite.models.transformer import TransformerModel
+from trainite.models.basic_transformer import BasicTransformerModel
+from trainite.models.rope_transformer import RoPETransformerModel
 
 __all__ = [
-    "TransformerModel",
+    "BasicTransformerModel",
+    "RoPETransformerModel",
 ]

--- a/trainite/models/basic_transformer.py
+++ b/trainite/models/basic_transformer.py
@@ -1,0 +1,180 @@
+import math
+from typing import Any
+
+import torch
+from torch import nn
+from torch.nn.utils.rnn import pad_sequence
+
+
+class Attention(nn.Module):
+    def __init__(self, embed_dim: int, num_heads: int, dropout: float = 0.1):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        if not self.num_heads * self.head_dim == self.embed_dim:
+            raise ValueError("embed_dim must be divisible by num_heads.")
+        self.qkv_projection = nn.Linear(embed_dim, embed_dim * 3, bias=False)
+        self.out = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.dropout = nn.Dropout(p=dropout)
+        self.dropout_p = dropout
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        padding_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        B, S, C = x.shape
+
+        qkv = self.qkv_projection(x)
+        q, k, v = qkv.chunk(3, dim=-1)
+
+        # Reshape for multi-head attention (B, S, num_heads, head_dim) and transpose to (B, num_heads, S, head_dim)
+        q = q.view(B, S, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(B, S, self.num_heads, self.head_dim).transpose(1, 2)
+        v = v.view(B, S, self.num_heads, self.head_dim).transpose(1, 2)
+
+        # padding mask shape should be (B,1,1,S) to broadcast correctly with attention scores of shape (B, num_heads, S, S)
+        if padding_mask is not None:
+            causal_mask = torch.ones(S, S, dtype=torch.bool, device=x.device).tril()
+            mask = causal_mask & padding_mask
+            context = nn.functional.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                is_causal=False,
+                dropout_p=self.dropout_p if self.training else 0.0,
+            )
+        else:
+            context = nn.functional.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                is_causal=True,
+                dropout_p=self.dropout_p if self.training else 0.0,
+            )
+        context = context.transpose(1, 2).contiguous().view(B, S, C)
+        out = self.out(context)
+        return self.dropout(out), context
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, d_model: int, num_heads: int, feedforward_dim: int, dropout: float = 0.1) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d_model)
+        self.attention = Attention(d_model, num_heads, dropout=dropout)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.feedforward = nn.Sequential(
+            nn.Linear(d_model, feedforward_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(feedforward_dim, d_model),
+            nn.Dropout(dropout),
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        padding_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        normed = self.norm1(x)
+        attn_output, _ = self.attention(normed, padding_mask=padding_mask)
+        x = x + attn_output
+
+        normed = self.norm2(x)
+        x = x + self.feedforward(normed)
+        return x
+
+
+class BasicTransformerModel(nn.Module):
+    """Decoder-only Transformer language model using absolute positional encoding."""
+
+    def __init__(
+        self,
+        vocab_size: int = 100,
+        hidden_size: int = 64,
+        num_layers: int = 2,
+        num_heads: int = 2,
+        feedforward_dim: int = 128,
+        dropout: float = 0.1,
+        max_seq_len: int = 128,
+        pad_token_id: int | None = None,
+    ) -> None:
+        super().__init__()
+        pad_token_id = pad_token_id if pad_token_id is not None else 0
+        self.embedding = nn.Embedding(vocab_size, hidden_size, padding_idx=pad_token_id)
+        self.pos_emb = nn.Embedding(max_seq_len, hidden_size)
+        self.blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    hidden_size,
+                    num_heads,
+                    feedforward_dim,
+                    dropout,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.proj = nn.Linear(hidden_size, vocab_size)
+        self.norm = nn.LayerNorm(hidden_size)
+
+    def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor | None = None) -> torch.Tensor:
+        B, S = input_ids.shape
+
+        if attention_mask is not None:
+            positions = (attention_mask.cumsum(dim=-1) - 1).clamp(min=0)
+        else:
+            positions = torch.arange(S, device=input_ids.device).unsqueeze(0)
+
+        x = self.embedding(input_ids) * math.sqrt(self.embedding.embedding_dim) + self.pos_emb(positions)
+
+        padding_mask: torch.Tensor | None = None
+        if attention_mask is not None:
+            if not attention_mask.all().item():
+                padding_mask = attention_mask.reshape(B, 1, 1, S).to(torch.bool)
+        elif (input_ids == self.embedding.padding_idx).any().item():
+            padding_mask = (input_ids != self.embedding.padding_idx).reshape(B, 1, 1, S)
+
+        for block in self.blocks:
+            x = block(x, padding_mask=padding_mask)
+        x = self.norm(x)
+        return self.proj(x)
+
+
+class CausalLMCollateFn:
+    """Collate sequences for decoder-only autoregressive training."""
+
+    def __init__(self, tokenizer: Any) -> None:
+        self.tokenizer = tokenizer
+        pad_id = getattr(tokenizer, "pad_token_id", None)
+        self.pad_token_id = pad_id if pad_id is not None else 0
+        self.ignore_index = -100
+
+    def __call__(self, batch: list[Any]) -> dict[str, torch.Tensor]:
+        input_ids_list = []
+        attention_mask_list = []
+        labels_list = []
+        for item in batch:
+            input_ids = item.train_input_ids
+            labels = item.train_label_ids
+            attention_mask = item.attention_mask
+
+            # We flip the sequences to have padding on the left, which allows us to use causal masking without modification
+            input_ids_list.append(input_ids.flip(0))
+            labels_list.append(labels.flip(0))
+            attention_mask_list.append(attention_mask.flip(0))
+
+        padded_input_ids = pad_sequence(
+            input_ids_list,
+            batch_first=True,
+            padding_value=self.pad_token_id if self.pad_token_id is not None else 0,
+        ).flip(1)
+        padded_attention_mask = pad_sequence(attention_mask_list, batch_first=True, padding_value=0).flip(1)
+        padded_labels = pad_sequence(labels_list, batch_first=True, padding_value=self.ignore_index).flip(1)
+
+        return {
+            "input_ids": padded_input_ids,
+            "attention_mask": padded_attention_mask,
+            "labels": padded_labels,
+        }

--- a/trainite/models/rope_transformer.py
+++ b/trainite/models/rope_transformer.py
@@ -140,7 +140,9 @@ class TransformerBlock(nn.Module):
         return x
 
 
-class TransformerModel(nn.Module):
+class RoPETransformerModel(nn.Module):
+    """Decoder-only Transformer language model using Rotary Position Embeddings (RoPE)."""
+
     def __init__(
         self,
         vocab_size: int = 100,

--- a/trainite/templates/components/models/basic_transformer.md
+++ b/trainite/templates/components/models/basic_transformer.md
@@ -1,6 +1,6 @@
-# Transformer model
+# Basic Transformer model
 
-It is a decoder-only Transformer: given a sequence of token IDs, it predicts the next token at every position.
+It is a decoder-only Transformer using absolute positional encoding: given a sequence of token IDs, it predicts the next token at every position.
 
 ## What goes in / out
 
@@ -15,10 +15,10 @@ The trainer uses these logits with cross-entropy loss.
 
 The model is small and standard:
 
-1. **Embedding**
+1. **Token Embedding**
    Converts token IDs into vectors.
-2. **Positional encoding**
-   Adds token order information.
+2. **Absolute Positional Embedding**
+   Adds token position vectors (`nn.Embedding(max_seq_len, hidden_size)`). Position IDs are computed dynamically from `attention_mask` to support left-padded batches.
 3. **Transformer blocks**
    Repeated attention + feedforward layers.
 4. **Final projection**
@@ -30,13 +30,10 @@ The model is small and standard:
 Padding ID is `0`. The model ignores padded positions in attention.
 
 ### Sequence length
-`max_seq_len` represents the precomputed cache size for RoPE. Inputs longer than this will fall back to slower on-the-fly calculations.
+`max_seq_len` represents the maximum supported sequence length. Inputs cannot exceed this limit.
 
 ### Hidden size and heads
 `hidden_size` must be divisible by `num_heads`.
-
-### Rotary positional encoding
-`head_dim` (which is `hidden_size // num_heads`) must be even because RoPE rotates pairs of dimensions.
 
 ## Config knobs
 
@@ -64,13 +61,13 @@ A common choice is `2x` to `4x` of `hidden_size`.
 Dropout rate used in attention and feedforward layers.
 
 ### `max_seq_len`
-Precomputed cache size for the rotary position embeddings.
+Maximum sequence length supported by the positional embeddings.
 
 ## Minimal config example
 
 ```yaml
 model:
-  _target_: models.transformer.TransformerModel
+  _target_: models.basic_transformer.BasicTransformerModel
   hidden_size: 128
   num_layers: 4
   num_heads: 4
@@ -81,12 +78,11 @@ model:
 
 ## When to change this file
 
-Edit `models/transformer.py` if you want to:
+Edit `models/basic_transformer.py` if you want to:
 
 - make the model wider or deeper
 - swap attention or feedforward behavior
-- change how padding is handled
-- add caching, rotary embeddings, or other sequence features
+- change positional encoding strategy (e.g. sinusoidal vs learned)
 
 ## Good starting rule
 

--- a/trainite/templates/components/models/rope_transformer.md
+++ b/trainite/templates/components/models/rope_transformer.md
@@ -1,0 +1,100 @@
+# RoPE Transformer model
+
+It is a decoder-only Transformer with Rotary Position Embeddings (RoPE): given a sequence of token IDs, it predicts the next token at every position.
+
+## What goes in / out
+
+- **Input**:
+  - `input_ids` with shape `(batch, seq_len)`
+  - `attention_mask` (optional) with shape `(batch, seq_len)`
+- **Output**: logits with shape `(batch, seq_len, vocab_size)`
+
+The trainer uses these logits with cross-entropy loss.
+
+## What the model is made of
+
+The model is small and standard:
+
+1. **Embedding**
+   Converts token IDs into vectors.
+2. **Rotary Positional Encoding (RoPE)**
+   Applies relative position rotation to query and key vectors.
+3. **Transformer blocks**
+   Repeated attention + feedforward layers.
+4. **Final projection**
+   Maps hidden states back to vocabulary logits.
+
+## Practical notes
+
+### Padding
+Padding ID is `0`. The model ignores padded positions in attention.
+
+### Sequence length
+`max_seq_len` represents the precomputed cache size for RoPE. Inputs longer than this will fall back to slower on-the-fly calculations.
+
+### Hidden size and heads
+`hidden_size` must be divisible by `num_heads`.
+
+### Rotary positional encoding
+`head_dim` (which is `hidden_size // num_heads`) must be even because RoPE rotates pairs of dimensions.
+
+## Config knobs
+
+### `hidden_size`
+Size of the token embeddings and hidden states.
+
+Bigger values usually give more capacity, but cost more memory and time.
+
+### `num_layers`
+How many Transformer blocks to stack.
+
+More layers = more capacity, slower training.
+
+### `num_heads`
+How many attention heads to use.
+
+Choose a value that divides `hidden_size` cleanly.
+
+### `feedforward_dim`
+Size of the feedforward layer inside each block.
+
+A common choice is `2x` to `4x` of `hidden_size`.
+
+### `dropout`
+Dropout rate used in attention and feedforward layers.
+
+### `max_seq_len`
+Precomputed cache size for the rotary position embeddings.
+
+## Minimal config example
+
+```yaml
+model:
+  _target_: models.rope_transformer.RoPETransformerModel
+  hidden_size: 128
+  num_layers: 4
+  num_heads: 4
+  feedforward_dim: 256
+  dropout: 0.1
+  max_seq_len: 64
+```
+
+## When to change this file
+
+Edit `models/rope_transformer.py` if you want to:
+
+- make the model wider or deeper
+- swap attention or feedforward behavior
+- change how padding is handled
+- add caching or other sequence features
+
+## Good starting rule
+
+If the dataset is tiny, start with a small model:
+
+- `hidden_size=64`
+- `num_layers=2`
+- `num_heads=2`
+- `feedforward_dim=128`
+
+If training is stable and the model underfits, scale up from there.

--- a/trainite/templates/project/README.md
+++ b/trainite/templates/project/README.md
@@ -100,7 +100,7 @@ To disable checkpoint uploads while retaining ClearML metric logging, pass `outp
 
 ## Components
 
-### Model: {{model_name}}
+### Models: {{model_name}}
 {{model_docs}}
 
 ### Dataset: {{dataset_name}}


### PR DESCRIPTION
## Summary

This PR introduces a second decoder-only transformer model architecture using **Absolute Positional Encoding** (`BasicTransformerModel`) alongside the existing **RoPE** variant (`RoPETransformerModel`). It also updates the Trainite CLI (`trainite init`) to support selecting **multiple models** during project scaffolding.

---

## Key Changes

### 1. Model Architecture Split & New Model
- **`BasicTransformerModel`** (`trainite/models/basic_transformer.py`):
  - Decoder-only Transformer language model using learned absolute positional encoding (`nn.Embedding(max_seq_len, hidden_size)`).
  - Dynamically computes `position_ids` from `attention_mask.cumsum(dim=-1) - 1` (clamped to `min=0`) to natively support left-padded batch generation without shifting positional indices.
- **`RoPETransformerModel`** (`trainite/models/rope_transformer.py`):
  - Moved existing RoPE-based model into `rope_transformer.py` and renamed class to `RoPETransformerModel`.
- **Exporting & Registry**:
  - Registered components under CLI names `basic-transformer` and `rope-transformer`.
  - Re-exported both classes from `trainite.models`.

### 2. Multi-Model CLI Scaffolding (`trainite init`)
- Updated `Init.model` CLI argument to accept space-separated multiple choices:
  ```bash
  trainite init my-experiment --model rope-transformer basic-transformer
  ```
- All selected model source files (`models/rope_transformer.py`, `models/basic_transformer.py`) are copied into the generated project's `models/` directory.
- `config.yaml` uses the first specified model as the default active model; users can switch between available models by changing `_target_`.
- Updated interactive mode (`run_interactive_mode`) to use multi-select checkboxes (`questionary.checkbox`).
- Added Pydantic field validation (`validate_models`) to reject duplicate model inputs with an explicit `ValueError`.

### 3. Documentation & Component Templates
- Added component documentation template `basic_transformer.md` and updated `rope_transformer.md`.
- Updated generated project `README.md` template to render documentation for all selected models.

### 4. Tests
- Refactored `tests/models/transformer_test.py` to use `@pytest.mark.parametrize` for shared test coverage across both `Basic` and `RoPE` attention, transformer blocks, model forwards, and collate functions.
- Updated `tests/cli_test.py` to cover multi-model CLI scaffolding and duplicate validation errors.

---