### PR TITLE
Remove redundant model configs

### DIFF
--- a/trainite/config/datasets.py
+++ b/trainite/config/datasets.py
@@ -1,10 +1,9 @@
 from typing import Literal, Self
-from pydantic import Field, ConfigDict, model_validator
+from pydantic import Field, model_validator
 from trainite.config.base import DatasetConfig, TransformConfig, DataWithAutoSplit, DataLoaderConfig
 
 
 class PromptCompletionTransformConfig(TransformConfig):
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: Literal[
         "trainite.datasets.string_reverse.PromptCompletionTransform",
         "datasets.string_reverse.PromptCompletionTransform",
@@ -16,7 +15,6 @@ class PromptCompletionTransformConfig(TransformConfig):
 
 
 class StringReverseDatasetConfig(DatasetConfig):
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: Literal[
         "trainite.datasets.string_reverse.StringReverseDataset", "datasets.string_reverse.StringReverseDataset"
     ] = Field(
@@ -59,7 +57,6 @@ class StringReverseDataConfig(DataWithAutoSplit):
 
 
 class CountingTransformConfig(TransformConfig):
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: Literal[
         "trainite.datasets.counting.CountingTransform",
         "datasets.counting.CountingTransform",
@@ -71,7 +68,6 @@ class CountingTransformConfig(TransformConfig):
 
 
 class CountingDatasetConfig(DatasetConfig):
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: Literal[
         "trainite.datasets.counting.CountingDataset",
         "datasets.counting.CountingDataset",

--- a/trainite/config/models.py
+++ b/trainite/config/models.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import ConfigDict, Field
+from pydantic import Field
 
 from trainite.config.base import ModelConfig
 
@@ -8,7 +8,6 @@ from trainite.config.base import ModelConfig
 class BasicTransformerModelConfig(ModelConfig):
     """Configuration for the BasicTransformerModel (absolute positional encoding)."""
 
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: Literal[
         "trainite.models.basic_transformer.BasicTransformerModel",
         "models.basic_transformer.BasicTransformerModel",
@@ -24,7 +23,6 @@ class BasicTransformerModelConfig(ModelConfig):
 class RoPETransformerModelConfig(ModelConfig):
     """Configuration for the RoPETransformerModel (rotary positional embeddings)."""
 
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: Literal[
         "trainite.models.rope_transformer.RoPETransformerModel",
         "models.rope_transformer.RoPETransformerModel",

--- a/trainite/config/preprocessors.py
+++ b/trainite/config/preprocessors.py
@@ -1,9 +1,8 @@
-from pydantic import Field, ConfigDict
+from pydantic import Field
 from trainite.config.base import PreprocessorConfig
 
 
 class CharTokenizerConfig(PreprocessorConfig):
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
     target: str = Field(
         default="trainite.preprocessors.char_tokenizer.CharTokenizer",
         alias="_target_",


### PR DESCRIPTION
## Summary

- Remove redundant `model_config` declarations from specialized config classes.
- Rely on the configuration inherited from the corresponding base config classes.
- Remove now-unused `ConfigDict` imports.

## Testing

- `uv run pytest`
- 105 passed, 5 skipped

Closes #132