### PR TITLE
Import self from typing_extensions

### DIFF
--- a/examples/counting/config.py
+++ b/examples/counting/config.py
@@ -1,4 +1,5 @@
-from typing import Self, Literal
+from typing import Literal
+from typing_extensions import Self
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 

--- a/examples/string_reversal/config.py
+++ b/examples/string_reversal/config.py
@@ -1,4 +1,5 @@
-from typing import Self, Literal
+from typing import Literal
+from typing_extensions import Self
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 

--- a/trainite/config/base.py
+++ b/trainite/config/base.py
@@ -1,4 +1,5 @@
-from typing import Self, Literal
+from typing import Literal
+from typing_extensions import Self
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 

--- a/trainite/config/datasets.py
+++ b/trainite/config/datasets.py
@@ -1,4 +1,5 @@
-from typing import Literal, Self
+from typing import Literal
+from typing_extensions import Self
 from pydantic import Field, model_validator
 from trainite.config.base import DatasetConfig, TransformConfig, DataWithAutoSplit, DataLoaderConfig
 


### PR DESCRIPTION
This PR imports `Self` from `typing_extensions` since Python 3.10 doesn't support `from typing import Self`