### PR TITLE
fix(cli): handle cancelled model selection

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -245,6 +245,20 @@ def test_duplicate_models_raises_error():
         Init(model=("rope-transformer", "rope-transformer"))
 
 
+def test_interactive_model_selection_cancel_exits_cleanly():
+    from unittest import mock
+
+    from trainite.cli.init import _prompt_multi_choice
+
+    with mock.patch("trainite.cli.init.questionary.checkbox") as checkbox:
+        checkbox.return_value.ask.return_value = None
+
+        with pytest.raises(SystemExit) as exc_info:
+            _prompt_multi_choice("Model(s):", ("rope-transformer",), default=("rope-transformer",))
+
+    assert exc_info.value.code == 0
+
+
 def test_init_with_sky_flag(tmp_path):
     project_dir = tmp_path / "sky-experiment"
     config = Init(project_dir=str(project_dir), sky=True)

--- a/trainite/cli/init.py
+++ b/trainite/cli/init.py
@@ -79,7 +79,9 @@ def _prompt_multi_choice(
         choices=formatted_choices,
         instruction=instruction,
     ).ask()
-    if result is None or len(result) == 0:
+    if result is None:
+        raise SystemExit(0)
+    if len(result) == 0:
         raise SystemExit("At least one model must be selected.")
     return result
 


### PR DESCRIPTION
## Summary

- exit cleanly when the interactive model checkbox is cancelled
- keep the existing validation error for an empty model selection
- add a regression test for the cancellation path

Fixes #137

## Testing

- `uv run pytest tests/cli_test.py -k interactive_model_selection_cancel_exits_cleanly -q`
- `PYTHONUTF8=1 uv run pytest -q`
- `uv run pre-commit run --all-files`