### PR TITLE
fix(tokenizer): preserve special tokens during truncation

### DIFF
--- a/tests/preprocessors/char_test.py
+++ b/tests/preprocessors/char_test.py
@@ -97,8 +97,33 @@ def test_char_tokenizer_call_return_tensors():
 def test_char_tokenizer_call_truncation():
     tokenizer = CharTokenizer()
     result = tokenizer("hello world this is a long string", add_special_tokens=True, truncation=True, max_length=5)
-    # Should be truncated to max_length (including special tokens)
+    # Should be truncated to max_length while retaining both special tokens.
     assert len(result["input_ids"]) == 5
+    assert result["input_ids"][0] == tokenizer.bos_token_id
+    assert result["input_ids"][-1] == tokenizer.eos_token_id
+    assert result["attention_mask"] == [1] * 5
+
+
+def test_char_tokenizer_call_truncation_without_special_tokens():
+    tokenizer = CharTokenizer()
+    result = tokenizer("hello", add_special_tokens=False, truncation=True, max_length=3)
+    assert result["input_ids"] == tokenizer.encode("hel")
+    assert result["attention_mask"] == [1] * 3
+
+
+@pytest.mark.parametrize("max_length", [0, 1])
+def test_char_tokenizer_call_truncation_short_max_length(max_length: int):
+    tokenizer = CharTokenizer()
+    result = tokenizer("hello", truncation=True, max_length=max_length)
+    expected_ids = [] if max_length == 0 else [tokenizer.bos_token_id]
+    assert result["input_ids"] == expected_ids
+    assert result["attention_mask"] == [1] * len(expected_ids)
+
+
+def test_char_tokenizer_call_truncation_rejects_negative_max_length():
+    tokenizer = CharTokenizer()
+    with pytest.raises(ValueError, match="max_length must be non-negative"):
+        tokenizer("hello", truncation=True, max_length=-1)
 
 
 def test_char_tokenizer_call_no_special_tokens():

--- a/trainite/preprocessors/char_tokenizer.py
+++ b/trainite/preprocessors/char_tokenizer.py
@@ -126,7 +126,12 @@ class CharTokenizer:
                 ids = prefix + ids + suffix
 
             if truncation and max_length is not None:
-                ids = ids[:max_length]
+                if max_length < 0:
+                    raise ValueError("max_length must be non-negative")
+                if len(ids) > max_length and add_special_tokens and max_length >= 2:
+                    ids = ids[: max_length - 1] + [self.eos_token_id]
+                else:
+                    ids = ids[:max_length]
 
             batch_input_ids.append(ids)
             batch_attention_mask.append([1] * len(ids))


### PR DESCRIPTION
## Summary

- preserve BOS and EOS when truncating `CharTokenizer` inputs with room for both special tokens
- keep no-special-token truncation unchanged and define short and negative `max_length` behavior
- add focused coverage for special tokens, no special tokens, attention masks, and short limits

Fixes #143

## Testing

- `uv run pytest tests/preprocessors/char_test.py -q`
- `PYTHONUTF8=1 uv run pytest -q`
- `uv run pre-commit run --all-files`