### PR TITLE
test: validate component registry

### DIFF
--- a/tests/config/registry_test.py
+++ b/tests/config/registry_test.py
@@ -1,0 +1,52 @@
+from trainite.config.registry import REGISTRY
+from trainite.shared.utils import get_target
+
+
+def test_model_registry_names():
+    assert "basic-transformer" in REGISTRY["models"]
+    assert "rope-transformer" in REGISTRY["models"]
+
+
+def test_dataset_registry_names():
+    assert "string-reverse" in REGISTRY["datasets"]
+    assert "counting" in REGISTRY["datasets"]
+    assert "hugging-face" in REGISTRY["datasets"]
+
+
+def test_trainer_registry_names():
+    assert "decoder-trainer" in REGISTRY["trainers"]
+
+
+def test_preprocessor_registry_names():
+    assert "char" in REGISTRY["preprocessors"]
+    assert "gpt2" in REGISTRY["preprocessors"]
+
+
+def test_implementation_paths_exist():
+    for specs in REGISTRY.values():
+        for spec in specs.values():
+            assert spec.implementation_path.is_file()
+
+
+def test_readme_template_paths_exist():
+    for specs in REGISTRY.values():
+        for spec in specs.values():
+            if spec.readme_template_path is not None:
+                assert spec.readme_template_path.is_file()
+
+
+def test_config_cls_paths_resolve():
+    for specs in REGISTRY.values():
+        for spec in specs.values():
+            get_target(spec.config_cls_path)
+
+
+def test_dataset_config_cls_paths_resolve():
+    for spec in REGISTRY["datasets"].values():
+        get_target(spec.dataset_config_cls_path)
+
+
+def test_collate_fn_targets_resolve():
+    for spec in REGISTRY["models"].values():
+        if spec.collate_fn_target is not None:
+            get_target(spec.collate_fn_target)

--- a/tests/config/registry_test.py
+++ b/tests/config/registry_test.py
@@ -1,52 +1,36 @@
-from trainite.config.registry import REGISTRY
+from pathlib import Path
+
+import pytest
+
+from trainite.config.registry import REGISTRY, DatasetSpec, ModelSpec
 from trainite.shared.utils import get_target
 
-
-def test_model_registry_names():
-    assert "basic-transformer" in REGISTRY["models"]
-    assert "rope-transformer" in REGISTRY["models"]
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_dataset_registry_names():
-    assert "string-reverse" in REGISTRY["datasets"]
-    assert "counting" in REGISTRY["datasets"]
-    assert "hugging-face" in REGISTRY["datasets"]
+def _registered_specs():
+    for group_name, specs in REGISTRY.items():
+        for component_name, spec in specs.items():
+            yield pytest.param(spec, id=f"{group_name}/{component_name}")
 
 
-def test_trainer_registry_names():
-    assert "decoder-trainer" in REGISTRY["trainers"]
+def test_registry_groups_are_populated():
+    assert set(REGISTRY) == {"models", "datasets", "trainers", "preprocessors"}
+    for group_name, specs in REGISTRY.items():
+        assert specs, f"registry group '{group_name}' has no components"
 
 
-def test_preprocessor_registry_names():
-    assert "char" in REGISTRY["preprocessors"]
-    assert "gpt2" in REGISTRY["preprocessors"]
+@pytest.mark.parametrize("spec", _registered_specs())
+def test_registry_spec_resolves(spec):
+    assert (PROJECT_ROOT / spec.implementation_path).is_file()
 
+    if spec.readme_template_path is not None:
+        assert (PROJECT_ROOT / spec.readme_template_path).is_file()
 
-def test_implementation_paths_exist():
-    for specs in REGISTRY.values():
-        for spec in specs.values():
-            assert spec.implementation_path.is_file()
+    get_target(spec.config_cls_path)
 
-
-def test_readme_template_paths_exist():
-    for specs in REGISTRY.values():
-        for spec in specs.values():
-            if spec.readme_template_path is not None:
-                assert spec.readme_template_path.is_file()
-
-
-def test_config_cls_paths_resolve():
-    for specs in REGISTRY.values():
-        for spec in specs.values():
-            get_target(spec.config_cls_path)
-
-
-def test_dataset_config_cls_paths_resolve():
-    for spec in REGISTRY["datasets"].values():
+    if isinstance(spec, DatasetSpec):
         get_target(spec.dataset_config_cls_path)
 
-
-def test_collate_fn_targets_resolve():
-    for spec in REGISTRY["models"].values():
-        if spec.collate_fn_target is not None:
-            get_target(spec.collate_fn_target)
+    if isinstance(spec, ModelSpec) and spec.collate_fn_target is not None:
+        get_target(spec.collate_fn_target)


### PR DESCRIPTION
## Summary

* Add tests for component registry entries to ensure the registered components are correctly defined and accessible.
* Add validation for implementation and README template paths to ensure the referenced files exist and are correctly configured.
* Add validation for config, dataset config, and collate function targets using `get_target`.
* Improve test coverage around component registration and target resolution.

## Testing

* `uv run pytest` — **123 passed, 5 skipped**
* `uv run pre-commit run --all-files` — **passed**

Fixes #140
