### PR TITLE
refactor(tests): generate integration test combinations dynamically from registry

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -9,20 +9,34 @@ import yaml
 
 import pytest
 
-from trainite.config.registry import MODEL_SPECS, DATASET_SPECS, PREPROCESSOR_SPECS, TRAINER_SPECS
+from trainite.config.registry import DATASET_SPECS, MODEL_SPECS, PREPROCESSOR_SPECS, REGISTRY, TRAINER_SPECS
+
+
+def _generate_init_combinations() -> list[tuple[list[str], str, str]]:
+    """Dynamically generate project init combinations from registered components."""
+    model_names = list(REGISTRY["models"].keys())
+    dataset_names = list(REGISTRY["datasets"].keys())
+    trainer_names = list(REGISTRY["trainers"].keys())
+
+    combinations: list[tuple[list[str], str, str]] = []
+    # Single model combinations across all datasets and trainers
+    for model in model_names:
+        for dataset in dataset_names:
+            for trainer in trainer_names:
+                combinations.append(([model], dataset, trainer))
+
+    # Multi-model combinations to verify multi-model project generation
+    if len(model_names) > 1:
+        for dataset in dataset_names:
+            for trainer in trainer_names:
+                combinations.append((model_names, dataset, trainer))
+
+    return combinations
 
 
 @pytest.mark.parametrize(
     "models,dataset,trainer",
-    [
-        (["basic-transformer"], "string-reverse", "decoder-trainer"),
-        (["rope-transformer"], "string-reverse", "decoder-trainer"),
-        (["rope-transformer", "basic-transformer"], "string-reverse", "decoder-trainer"),
-        (["basic-transformer"], "counting", "decoder-trainer"),
-        (["rope-transformer"], "counting", "decoder-trainer"),
-        (["rope-transformer", "basic-transformer"], "counting", "decoder-trainer"),
-        (["rope-transformer"], "hugging-face", "decoder-trainer"),
-    ],
+    _generate_init_combinations(),
 )
 def test_init_generates_valid_project(models: list[str], dataset: str, trainer: str) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

Fixes #164

Replaces hard-coded model, dataset, and trainer parameter combinations in 	est_init_generates_valid_project with dynamically-generated combinations from REGISTRY (	rainite.config.registry).

- Added helper function _generate_init_combinations() in 	ests/cli_test.py that pulls registered models, datasets, and trainers from REGISTRY.
- Generates single-model combinations for every dataset and trainer, as well as multi-model combinations.
- Keeps tests maintainable so any new component added to REGISTRY is automatically covered by integration tests without manual updates.

## AI usage

- [ ] No AI tools were used for this contribution
- [x] AI tools were used to assist this contribution

**Tool(s) and usage:**

AI coding assistant used to analyze REGISTRY structures and draft parameter generation helpers; code reviewed, refined, and verified locally with pytest before submission.

## Testing

- [x] Tests added or updated where needed
- [x] Existing tests and checks pass
- [ ] Documentation updated if needed
