### PR TITLE
test: isolate generated-project integration test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,4 +167,8 @@ exclude = '''
   | foo.py
 )
 '''
-addopts = "--color=yes"
+[tool.pytest.ini_options]
+addopts = "--color=yes -m 'not integration'"
+markers = [
+    "integration: slow tests that build an isolated uv env and train a real step",
+]

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -101,20 +101,14 @@ def test_init_generates_valid_project(models: list[str], dataset: str, trainer: 
             assert generated_config["data"]["dataset"]["_target_"].startswith("dataset_impl.")
         assert generated_config["data"]["transform"]["_target_"].startswith("dataset_impl.")
 
+@pytest.mark.integration
+def test_generated_project_is_runnable() -> None:
+    """
+    generate one representative project, install its own declared dependencies
+    in an isolated uv environment, and run a minimal training workload.
+    """
+    model, dataset, trainer = "rope-transformer", "string-reverse", "decoder-trainer"
 
-@pytest.mark.parametrize(
-    "model,dataset,trainer",
-    [
-        ("basic-transformer", "string-reverse", "decoder-trainer"),
-        ("rope-transformer", "string-reverse", "decoder-trainer"),
-        ("basic-transformer", "counting", "decoder-trainer"),
-        ("rope-transformer", "counting", "decoder-trainer"),
-    ],
-)
-def test_generated_project_is_runnable(model: str, dataset: str, trainer: str) -> None:
-    """
-    Test that the generated project can actually be run for a few steps across all valid combinations.
-    """
     with tempfile.TemporaryDirectory() as temp_dir:
         project_dir = Path(temp_dir) / "runnable-project"
 
@@ -136,31 +130,52 @@ def test_generated_project_is_runnable(model: str, dataset: str, trainer: str) -
             check=True,
         )
 
-        # 2. Modify config.yaml to run for only 1 step/epoch to keep test fast
+        # 2. Modify config.yaml to run a minimal workload
         config_path = project_dir / "config.yaml"
+
         with open(config_path, "r") as f:
             config = yaml.safe_load(f)
 
-        # Base overrides for speed
         config["trainer"]["epochs"] = 1
         config["trainer"]["log_every_steps"] = 1
+
         config["model"]["num_layers"] = 1
         config["model"]["hidden_size"] = 16
         config["model"]["feedforward_dim"] = 32
 
-        # Dataset-specific overrides to keep sequences small
-        if dataset == "string-reverse":
-            config["data"]["dataset"]["per_seq_size"] = 16
-        elif dataset == "counting":
-            config["data"]["dataset"]["total_size"] = 16
+        config["data"]["dataset"]["per_seq_size"] = 16
+        config["data"]["dataloader"]["batch_size"] = 8
+        config["data"]["test_ratio"] = 0.1
+        config["data"]["val_ratio"] = 0.1
 
         with open(config_path, "w") as f:
             yaml.safe_dump(config, f)
 
-        # 3. Run the generated main.py
+        # 3. Install ONLY the generated project's dependencies
         try:
             subprocess.run(
-                [sys.executable, "main.py", "config.yaml"],
+                ["uv", "sync"],
+                cwd=project_dir,
+                check=True,
+                timeout=600,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            pytest.fail(
+                f"uv sync failed for generated project ({model} + {dataset}) "
+                f"-- likely a missing/incorrect dependency in generated pyproject.toml:\n"
+                f"STDOUT: {e.stdout}\nSTDERR: {e.stderr}"
+            )
+        except subprocess.TimeoutExpired:
+            pytest.fail(
+                f"uv sync timed out for generated project ({model} + {dataset})"
+            )
+
+        # 4. Run the generated project
+        try:
+            subprocess.run(
+                ["uv", "run", "python", "main.py", "config.yaml"],
                 cwd=project_dir,
                 check=True,
                 timeout=300,
@@ -169,14 +184,15 @@ def test_generated_project_is_runnable(model: str, dataset: str, trainer: str) -
             )
         except subprocess.CalledProcessError as e:
             pytest.fail(
-                f"Generated project failed to run ({model} + {dataset}):\nSTDOUT: {e.stdout}\nSTDERR: {e.stderr}"
+                f"Generated project failed to run ({model} + {dataset}):\n"
+                f"STDOUT: {e.stdout}\nSTDERR: {e.stderr}"
             )
         except subprocess.TimeoutExpired:
-            pytest.fail(f"Generated project timed out ({model} + {dataset})")
+            pytest.fail(
+                f"Generated project timed out ({model} + {dataset})"
+            )
         finally:
             logging.shutdown()
-
-
 def test_cli_main_routing(capsys):
     from trainite.cli.main import main
     from unittest import mock

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -101,6 +101,7 @@ def test_init_generates_valid_project(models: list[str], dataset: str, trainer: 
             assert generated_config["data"]["dataset"]["_target_"].startswith("dataset_impl.")
         assert generated_config["data"]["transform"]["_target_"].startswith("dataset_impl.")
 
+
 @pytest.mark.integration
 def test_generated_project_is_runnable() -> None:
     """
@@ -168,9 +169,7 @@ def test_generated_project_is_runnable() -> None:
                 f"STDOUT: {e.stdout}\nSTDERR: {e.stderr}"
             )
         except subprocess.TimeoutExpired:
-            pytest.fail(
-                f"uv sync timed out for generated project ({model} + {dataset})"
-            )
+            pytest.fail(f"uv sync timed out for generated project ({model} + {dataset})")
 
         # 4. Run the generated project
         try:
@@ -184,15 +183,14 @@ def test_generated_project_is_runnable() -> None:
             )
         except subprocess.CalledProcessError as e:
             pytest.fail(
-                f"Generated project failed to run ({model} + {dataset}):\n"
-                f"STDOUT: {e.stdout}\nSTDERR: {e.stderr}"
+                f"Generated project failed to run ({model} + {dataset}):\nSTDOUT: {e.stdout}\nSTDERR: {e.stderr}"
             )
         except subprocess.TimeoutExpired:
-            pytest.fail(
-                f"Generated project timed out ({model} + {dataset})"
-            )
+            pytest.fail(f"Generated project timed out ({model} + {dataset})")
         finally:
             logging.shutdown()
+
+
 def test_cli_main_routing(capsys):
     from trainite.cli.main import main
     from unittest import mock


### PR DESCRIPTION
Summary
This PR makes the generated-project integration test self-contained and keeps it out of the regular test path to keep CI lightweight while preserving regular test coverage.

What changed
- The integration test now runs in an isolated `uv` environment using only the generated project's declared dependencies, so missing dependencies fail directly.
- Reduced the training test to one representative combination (`rope-transformer` + `string-reverse`) with a minimal workload.
- Added the `integration` pytest marker and excluded integration tests from the default test run using pytest addopts.
- Lightweight generation tests still cover all model/dataset combinations on every PR.


Relates to #128

AI usage
- [x] AI tools were used to assist this contribution

Tool(s) and usage:
Claude was used to help understand the existing test structure and debug the isolated uv-based integration test setup.

Testing
- [x] Tests added or updated where needed
- [x] Existing tests and checks pass
- [ ] Documentation updated if needed
