### PR TITLE
docs: add overview and getting started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,1 +1,80 @@
 # Getting Started
+
+This guide creates a small local training project with Trainite's default
+components: the rotary-position Transformer, string-reversal dataset, and
+decoder trainer.
+
+## Requirements
+
+- Python 3.10 or newer
+- [`uv`](https://docs.astral.sh/uv/) (recommended) or `pip`
+
+## Install Trainite
+
+Install the latest release from PyPI:
+
+```bash
+pip install trainite
+```
+
+To work from a source checkout instead, install its dependencies with `uv`:
+
+```bash
+git clone https://github.com/pytorch-ignite/trainite.git
+cd trainite
+uv sync
+```
+
+Prefix the commands below with `uv run` when using the source checkout, for
+example `uv run trainite init`.
+
+## Create a project
+
+Run the interactive setup and answer each prompt:
+
+```bash
+trainite init
+```
+
+For a reproducible, non-interactive setup, pass the same choices explicitly:
+
+```bash
+trainite init my-experiment \
+  --model rope-transformer \
+  --dataset string-reverse \
+  --trainer decoder-trainer
+```
+
+Trainite creates `my-experiment/` with:
+
+- `config.yaml` for model, data, training, and output settings
+- `main.py` as the training entry point
+- local `models/`, `dataset_impl/`, and `trainer.py` implementations
+- `pyproject.toml` with the generated project's runtime dependencies
+- `README.md` with the selected components and recreation command
+
+## Run the experiment
+
+Install the generated project's dependencies and start training:
+
+=== "uv"
+
+    ```bash
+    cd my-experiment
+    uv sync
+    uv run python main.py config.yaml
+    ```
+
+=== "pip"
+
+    ```bash
+    cd my-experiment
+    pip install -e .
+    python main.py config.yaml
+    ```
+
+The run writes logs, checkpoints, and TensorBoard data beneath
+`outputs/rope_transformer__string_reverse/` in a timestamped directory.
+
+You now have a standalone project. Change `config.yaml` to tune the experiment,
+or edit the generated Python modules to replace the starter implementation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,27 @@
-# Trainite Documentation
+# Trainite
+
+Trainite generates self-contained PyTorch training projects from a small set of
+tested building blocks. Choose a model, dataset, and trainer, then use the
+generated project as a readable starting point for your experiment.
+
+The generated code belongs to your project. It includes the model, data
+pipeline, trainer, configuration, and declared dependencies needed to run the
+experiment, so the project does not need Trainite at runtime.
+
+## How it works
+
+1. Run `trainite init` and select starter components.
+2. Install the dependencies declared by the generated project.
+3. Run `main.py` with the generated `config.yaml`.
+4. Edit the local Python modules and configuration for your experiment.
+
+Trainite currently provides these starting points:
+
+- **Models:** basic Transformer and rotary-position Transformer
+- **Datasets:** string reversal, counting, and Hugging Face datasets
+- **Trainer:** decoder training powered by PyTorch-Ignite
+
+The command-line interface supports an interactive setup as well as explicit
+options for scripts and reproducible project generation.
+
+[Create your first project](getting-started.md){ .md-button .md-button--primary }


### PR DESCRIPTION
Completes Part 2 of #156.

Adds the project overview and a tested getting-started flow covering installation, `trainite init`, and the first training run.

Validation: `uv run --group docs mkdocs build --strict`; pre-commit on both pages; generated default project run end to end.

AI-assisted and actively reviewed.
