### PR TITLE
refactor(config): simplify model and dataset target types to str

### DIFF
--- a/trainite/config/datasets.py
+++ b/trainite/config/datasets.py
@@ -1,13 +1,10 @@
-from typing import Literal, Self
+from typing import Self
 from pydantic import Field, model_validator
 from trainite.config.base import DatasetConfig, TransformConfig, DataWithAutoSplit, DataLoaderConfig
 
 
 class PromptCompletionTransformConfig(TransformConfig):
-    target: Literal[
-        "trainite.datasets.string_reverse.PromptCompletionTransform",
-        "dataset_impl.string_reverse.PromptCompletionTransform",
-    ] = Field(
+    target: str = Field(
         default="trainite.datasets.string_reverse.PromptCompletionTransform",
         alias="_target_",
     )
@@ -15,10 +12,7 @@ class PromptCompletionTransformConfig(TransformConfig):
 
 
 class StringReverseDatasetConfig(DatasetConfig):
-    target: Literal[
-        "trainite.datasets.string_reverse.StringReverseDataset",
-        "dataset_impl.string_reverse.StringReverseDataset",
-    ] = Field(
+    target: str = Field(
         default="trainite.datasets.string_reverse.StringReverseDataset",
         alias="_target_",
     )
@@ -58,10 +52,7 @@ class StringReverseDataConfig(DataWithAutoSplit):
 
 
 class CountingTransformConfig(TransformConfig):
-    target: Literal[
-        "trainite.datasets.counting.CountingTransform",
-        "dataset_impl.counting.CountingTransform",
-    ] = Field(
+    target: str = Field(
         default="trainite.datasets.counting.CountingTransform",
         alias="_target_",
     )
@@ -69,10 +60,7 @@ class CountingTransformConfig(TransformConfig):
 
 
 class CountingDatasetConfig(DatasetConfig):
-    target: Literal[
-        "trainite.datasets.counting.CountingDataset",
-        "dataset_impl.counting.CountingDataset",
-    ] = Field(
+    target: str = Field(
         default="trainite.datasets.counting.CountingDataset",
         alias="_target_",
     )
@@ -112,10 +100,7 @@ class CountingDataConfig(DataWithAutoSplit):
 
 
 class HuggingFaceTransformConfig(TransformConfig):
-    target: Literal[
-        "trainite.datasets.hugging_face.HuggingFaceTransform",
-        "dataset_impl.hugging_face.HuggingFaceTransform",
-    ] = Field(
+    target: str = Field(
         default="trainite.datasets.hugging_face.HuggingFaceTransform",
         alias="_target_",
     )
@@ -124,7 +109,7 @@ class HuggingFaceTransformConfig(TransformConfig):
 
 
 class HuggingFaceDatasetConfig(DatasetConfig):
-    target: Literal["datasets.load_dataset"] = Field(default="datasets.load_dataset", alias="_target_")
+    target: str = Field(default="datasets.load_dataset", alias="_target_")
     path: str = Field(default="namespace/dataset-name", min_length=1)
     name: str | None = None
     split: str = Field(default="train", min_length=1)

--- a/trainite/config/models.py
+++ b/trainite/config/models.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from pydantic import Field
 
 from trainite.config.base import ModelConfig
@@ -8,10 +6,7 @@ from trainite.config.base import ModelConfig
 class BasicTransformerModelConfig(ModelConfig):
     """Configuration for the BasicTransformerModel (absolute positional encoding)."""
 
-    target: Literal[
-        "trainite.models.basic_transformer.BasicTransformerModel",
-        "models.basic_transformer.BasicTransformerModel",
-    ] = Field(default="trainite.models.basic_transformer.BasicTransformerModel", alias="_target_")
+    target: str = Field(default="trainite.models.basic_transformer.BasicTransformerModel", alias="_target_")
     hidden_size: int = Field(default=64, gt=0)
     num_layers: int = Field(default=2, gt=0)
     num_heads: int = Field(default=2, gt=0)
@@ -23,10 +18,7 @@ class BasicTransformerModelConfig(ModelConfig):
 class RoPETransformerModelConfig(ModelConfig):
     """Configuration for the RoPETransformerModel (rotary positional embeddings)."""
 
-    target: Literal[
-        "trainite.models.rope_transformer.RoPETransformerModel",
-        "models.rope_transformer.RoPETransformerModel",
-    ] = Field(default="trainite.models.rope_transformer.RoPETransformerModel", alias="_target_")
+    target: str = Field(default="trainite.models.rope_transformer.RoPETransformerModel", alias="_target_")
     hidden_size: int = Field(default=64, gt=0)
     num_layers: int = Field(default=2, gt=0)
     num_heads: int = Field(default=2, gt=0)


### PR DESCRIPTION
Follow up on discussion in #31.

### Description

Currently, several Pydantic configuration classes in `trainite/config/models.py` and `trainite/config/datasets.py` type their `target` (`_target_`) fields as multi-line `Literal[...]` unions duplicating full import paths (`"trainite.models..."` vs `"models..."`). This makes the config definitions unnecessarily verbose and rejects custom user-provided implementations with strict validation errors.

Following maintainer guidance (@aaishwarymishra in #31), this PR:
1. Replaces `Literal[...]` on `target` fields across `trainite/config/models.py` and `trainite/config/datasets.py` with `str`.
2. Preserves default values pointing to canonical module paths.
3. Adds unit test coverage in `tests/config/base_test.py` ensuring all model and dataset configs instantiate cleanly with string targets.
