### PR TITLE
feat: add UltraChat 200k dataset support

### DIFF
--- a/tests/datasets/ultrachat_200k_test.py
+++ b/tests/datasets/ultrachat_200k_test.py
@@ -1,0 +1,139 @@
+from typing import Any
+
+import pytest
+import torch
+
+from trainite.datasets.ultrachat_200k import UltraChat200kTransform
+
+
+class FakeTokenizer:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def __call__(
+        self,
+        text: str,
+        add_special_tokens: bool = True,
+        truncation: bool = True,
+        max_length: int = 128,
+    ) -> dict[str, Any]:
+        self.calls.append(text)
+        words = text.strip().split()
+        ids = [1] + [10 + i for i in range(len(words))] + [2]
+        attention_mask = [1] * len(ids)
+
+        if truncation and max_length is not None:
+            ids = ids[:max_length]
+            attention_mask = attention_mask[:max_length]
+
+        return {
+            "input_ids": ids,
+            "attention_mask": attention_mask,
+        }
+
+
+def test_ultrachat_transform():
+    tokenizer = FakeTokenizer()
+    transform = UltraChat200kTransform(tokenizer=tokenizer, max_length=16)
+
+    sample = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+            {"role": "user", "content": "how are you?"},
+            {"role": "assistant", "content": "I am good."},
+        ]
+    }
+
+    datapoint = transform(sample)
+
+    assert datapoint.source == ("User: hello\nAssistant: world\nUser: how are you?\nAssistant: ")
+    assert datapoint.target == "I am good."
+
+    assert datapoint.train_input_ids.dtype == torch.long
+    assert datapoint.train_label_ids.dtype == torch.long
+    assert datapoint.attention_mask.dtype == torch.long
+    assert datapoint.eval_input_ids.dtype == torch.long
+
+    assert torch.equal(
+        datapoint.train_input_ids,
+        torch.tensor([1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21], dtype=torch.long),
+    )
+    assert torch.equal(
+        datapoint.train_label_ids,
+        torch.tensor([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 2], dtype=torch.long),
+    )
+    assert torch.equal(
+        datapoint.attention_mask,
+        torch.tensor([1] * 13, dtype=torch.long),
+    )
+    assert torch.equal(
+        datapoint.eval_input_ids,
+        torch.tensor([1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 2], dtype=torch.long),
+    )
+
+    # Full conversation was tokenized for training
+    assert tokenizer.calls[0] == ("User: hello\nAssistant: world\nUser: how are you?\nAssistant: I am good.\n")
+
+
+def test_ultrachat_transform_user_ended_conversation():
+    tokenizer = FakeTokenizer()
+    transform = UltraChat200kTransform(tokenizer=tokenizer, max_length=16)
+
+    sample = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+            {"role": "user", "content": "final question"},
+        ]
+    }
+
+    datapoint = transform(sample)
+
+    assert datapoint.source == ("User: hello\nAssistant: world\nUser: final question\nAssistant: ")
+    assert datapoint.target == ""
+
+
+def test_ultrachat_transform_truncates_to_max_length():
+    tokenizer = FakeTokenizer()
+    transform = UltraChat200kTransform(tokenizer=tokenizer, max_length=3)
+
+    sample = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+    }
+
+    datapoint = transform(sample)
+
+    assert torch.equal(
+        datapoint.train_input_ids,
+        torch.tensor([1, 10], dtype=torch.long),
+    )
+    assert torch.equal(
+        datapoint.train_label_ids,
+        torch.tensor([10, 11], dtype=torch.long),
+    )
+    assert torch.equal(
+        datapoint.attention_mask,
+        torch.tensor([1, 1], dtype=torch.long),
+    )
+
+
+def test_ultrachat_transform_rejects_small_max_length():
+    tokenizer = FakeTokenizer()
+
+    with pytest.raises(ValueError, match="at least 2"):
+        UltraChat200kTransform(tokenizer=tokenizer, max_length=1)
+
+
+def test_ultrachat_transform_rejects_invalid_messages():
+    tokenizer = FakeTokenizer()
+    transform = UltraChat200kTransform(tokenizer=tokenizer, max_length=16)
+
+    with pytest.raises(ValueError, match="messages must be a list"):
+        transform({"messages": "not a list"})
+
+    with pytest.raises(ValueError, match="each message in messages must be a dict"):
+        transform({"messages": [{"role": "user", "content": "hi"}, "invalid"]})

--- a/trainite/config/datasets.py
+++ b/trainite/config/datasets.py
@@ -189,3 +189,45 @@ class WikiTextDataConfig(DataConfigBase):
             ),
         )
     )
+
+
+class UltraChat200kTransformConfig(TransformConfig):
+    target: str = Field(
+        default="trainite.datasets.ultrachat_200k.UltraChat200kTransform",
+        alias="_target_",
+    )
+    max_length: int = Field(default=128, gt=1)
+
+
+class UltraChat200kDatasetConfig(HuggingFaceDatasetConfig):
+    # https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
+    path: str = "HuggingFaceH4/ultrachat_200k"
+    name: str = "default"
+
+
+class UltraChat200kDataConfig(DataConfigBase):
+    train: SplitConfig = Field(
+        default_factory=lambda: SplitConfig(
+            dataset=UltraChat200kDatasetConfig(
+                split="train_sft",
+            ),
+            transform=UltraChat200kTransformConfig(),
+            dataloader=DataLoaderConfig(
+                batch_size=32,
+                shuffle=True,
+            ),
+        )
+    )
+
+    val: SplitConfig = Field(
+        default_factory=lambda: SplitConfig(
+            dataset=UltraChat200kDatasetConfig(
+                split="test_sft",
+            ),
+            transform=UltraChat200kTransformConfig(),
+            dataloader=DataLoaderConfig(
+                batch_size=32,
+                shuffle=False,
+            ),
+        )
+    )

--- a/trainite/config/registry.py
+++ b/trainite/config/registry.py
@@ -99,6 +99,17 @@ DATASET_SPECS = {
         preprocessor_spec_name="gpt2",
         dependencies=["datasets"],
     ),
+    "ultrachat-200k": DatasetSpec(
+        name="ultrachat_200k",
+        implementation_path=Path("trainite/datasets/ultrachat_200k.py"),
+        config_cls_path="trainite.config.datasets.UltraChat200kDataConfig",
+        dataset_config_cls_path="trainite.config.datasets.UltraChat200kDatasetConfig",
+        implementation_symbol="UltraChat200kTransform",
+        builder_symbol="datasets.load_dataset",
+        readme_template_path=Path("trainite/templates/components/datasets/ultrachat_200k.md"),
+        preprocessor_spec_name="gpt2",
+        dependencies=["datasets"],
+    ),
 }
 
 TRAINER_SPECS = {

--- a/trainite/datasets/__init__.py
+++ b/trainite/datasets/__init__.py
@@ -6,10 +6,12 @@ from trainite.datasets.counting import (
 )
 from trainite.datasets.hugging_face import HuggingFaceTransform
 from trainite.datasets.wikitext import WikiTextTransform
+from trainite.datasets.ultrachat_200k import UltraChat200kTransform
 
 __all__ = [
     "StringReverseDataset",
     "CountingDataset",
     "HuggingFaceTransform",
     "WikiTextTransform",
+    "UltraChat200kTransform",
 ]

--- a/trainite/datasets/ultrachat_200k.py
+++ b/trainite/datasets/ultrachat_200k.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+import torch
+from pydantic import BaseModel, ConfigDict
+
+
+class DatapointModel(BaseModel):
+    """Tokenized UltraChat 200k sample used by Trainite's causal LM pipeline."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    source: str
+    target: str
+    train_input_ids: torch.Tensor
+    train_label_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    eval_input_ids: torch.Tensor
+
+
+class UltraChat200kTransform:
+    """Convert an UltraChat 200k sample into a causal language-modeling datapoint.
+
+    Multi-turn conversation messages are formatted into a standard text prompt.
+    The formatted conversation is used as the autoregressive training sequence.
+
+    Special tokens are added by the tokenizer.
+    """
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        max_length: int = 128,
+    ) -> None:
+        if max_length < 2:
+            raise ValueError("max_length must be at least 2")
+
+        self.tokenizer = tokenizer
+        self.max_length = max_length
+
+    @staticmethod
+    def _render_messages(messages: list[dict[str, Any]]) -> str:
+        return "".join(
+            f"{str(message.get('role', 'user')).strip().capitalize()}: {str(message.get('content', '')).strip()}\n"
+            for message in messages
+        )
+
+    def __call__(self, sample: dict[str, Any]) -> DatapointModel:
+        messages = sample.get("messages")
+
+        if not isinstance(messages, list):
+            raise ValueError("messages must be a list")
+
+        for message in messages:
+            if not isinstance(message, dict):
+                raise ValueError("each message in messages must be a dict")
+
+        conversation = self._render_messages(messages)
+
+        tokenized = self.tokenizer(
+            conversation,
+            add_special_tokens=True,
+            truncation=True,
+            max_length=self.max_length,
+        )
+
+        token_ids = tokenized["input_ids"]
+        attention_mask = tokenized["attention_mask"]
+
+        train_input_ids = torch.tensor(
+            token_ids[:-1],
+            dtype=torch.long,
+        )
+        train_label_ids = torch.tensor(
+            token_ids[1:],
+            dtype=torch.long,
+        )
+        train_attention_mask = torch.tensor(
+            attention_mask[:-1],
+            dtype=torch.long,
+        )
+
+        if messages and str(messages[-1].get("role", "")).strip().lower() == "assistant":
+            eval_messages = messages[:-1]
+            target = str(messages[-1].get("content", "")).strip()
+        else:
+            eval_messages = messages
+            target = ""
+
+        eval_prompt = f"{self._render_messages(eval_messages)}Assistant: "
+
+        eval_tokenized = self.tokenizer(
+            eval_prompt,
+            add_special_tokens=True,
+            truncation=True,
+            max_length=self.max_length,
+        )
+
+        return DatapointModel(
+            source=eval_prompt,
+            target=target,
+            train_input_ids=train_input_ids,
+            train_label_ids=train_label_ids,
+            attention_mask=train_attention_mask,
+            eval_input_ids=torch.tensor(
+                eval_tokenized["input_ids"],
+                dtype=torch.long,
+            ),
+        )

--- a/trainite/templates/components/datasets/ultrachat_200k.md
+++ b/trainite/templates/components/datasets/ultrachat_200k.md
@@ -1,0 +1,56 @@
+# UltraChat 200k dataset
+
+This built-in dataset loads the UltraChat 200k dataset from Hugging Face
+Datasets and applies a multi-turn conversation transform for causal language-modeling.
+
+## Configure the dataset
+
+The default configuration uses the UltraChat 200k dataset with explicit train and validation splits:
+
+```yaml
+data:
+  train:
+    dataset:
+      path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+  val:
+    dataset:
+      path: HuggingFaceH4/ultrachat_200k
+      split: test_sft
+```
+
+UltraChat samples contain a `messages` field with `role` and `content` for each conversation turn.
+
+## Configure the transform
+
+Each split uses a transform configured with:
+
+```yaml
+data:
+  train:
+    transform:
+      max_length: 128
+```
+
+`max_length` controls the maximum sequence length.
+
+The transform renders each turn as `User: <content>\n` and `Assistant: <content>\n`.
+The tokenizer handles special-token addition. The transform creates:
+
+* `train_input_ids`
+* `train_label_ids`
+* `attention_mask`
+* `eval_input_ids`
+
+During evaluation and inference logging, the prompt preserves the multi-turn context and ends with
+`Assistant: ` so the model generates the final assistant response.
+
+## Dataset splits
+
+The `train_sft` split is used for training and `test_sft` is mapped to Trainite's validation split.
+The generation-ranking splits (`train_gen` and `test_gen`) are outside the scope of this built-in wrapper.
+
+## Hugging Face authentication
+
+The dataset is downloaded and cached by Hugging Face Datasets. Do not put Hugging Face access
+tokens in `config.yaml`. Authenticate through the Hugging Face CLI or the environment when required.


### PR DESCRIPTION
## Summary

adds built-in UltraChat 200k (`HuggingFaceH4/ultrachat_200k`) dataset support for multi-turn conversational language modeling

addresses part of #125

### key implementation details

- **transform:** formats messages as `User: <content>\n` / `Assistant: <content>\n` for causal language modeling
- **evaluation:** preserves multi-turn context up to the final user turn and ends with `Assistant: ` user-ended conversations keep the final message
- **splits:** maps `train_sft` to training and `test_sft` to validation `train_gen` / `test_gen` are out of scope
- **config & registry:** adds typed configs and registers the dataset with the GPT-2 tokenizer preprocessor
- **documentation:** adds the UltraChat 200k dataset template

## AI usage

<!-- Select one option and provide details when AI was used. -->

- [ ] No AI tools were used for this contribution
- [x] AI tools were used to assist this contribution

**Tool(s) and usage:**

ai assistants (`ChatGPT`, `Antigravity`, `ZCode`) were used during development for implementation support, debugging, and code review

## Testing

<!-- List the checks you ran, or explain why testing was not applicable. -->

- [x] Tests added or updated where needed
- [x] Existing tests and checks pass
- [x] Documentation updated if needed

### verification details

- **unit tests:** 5/5 UltraChat tests passed
- **full test suite:** 138 tests passed 1 deselected
- **Ruff:** `uvx ruff check trainite/ tests/` passed
- **pre-commit:** `uv run pre-commit run --all-files` passed including Ruff formatting and Pyrefly type checking
- **cli generation:** `trainite init my-chat-model --dataset ultrachat-200k` successfully generated the project and config with `train_sft` and `test_sft`
- **real dataset:** successfully loaded UltraChat 200k from Hugging Face
  - `train_sft`: 207865 examples
  - `test_sft`: 23110 examples
- **training integration:** the generated project entered the real training loop and ran for 330 iterations the logged loss decreased from `10.9655` to `9.2114` before the run was interrupted
- **manual validation:** verified the transform with the same GPT-2 tokenizer used by Trainite including multi-turn formatting causal token alignment evaluation prompt construction and user-ended conversations